### PR TITLE
Fix diff calculation change to wait for the fork block

### DIFF
--- a/src/cryptonote_basic/difficulty.h
+++ b/src/cryptonote_basic/difficulty.h
@@ -53,5 +53,5 @@ namespace cryptonote
      */
     bool check_hash(const crypto::hash &hash, difficulty_type difficulty);
     difficulty_type next_difficulty(std::vector<std::uint64_t> timestamps, std::vector<difficulty_type> cumulative_difficulties, size_t target_seconds);
-	difficulty_type next_difficulty_v2(std::vector<std::uint64_t> timestamps, std::vector<difficulty_type> cumulative_difficulties, size_t target_seconds);
+	difficulty_type next_difficulty_lwma(std::vector<std::uint64_t> timestamps, std::vector<difficulty_type> cumulative_difficulties, const uint8_t version);
 }

--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -88,6 +88,7 @@
 #define DIFFICULTY_WINDOW_V3                            17
 #define DIFFICULTY_LAG                                  15  // !!!
 #define DIFFICULTY_CUT                                  60  // timestamps to cut after sorting
+#define DIFFICULTY_BLOCKS_COUNT_V3                      (DIFFICULTY_WINDOW_V3 + 1)
 #define DIFFICULTY_BLOCKS_COUNT_V2                      (DIFFICULTY_WINDOW_V2 + 1) // added to make N=N
 #define DIFFICULTY_BLOCKS_COUNT                         DIFFICULTY_WINDOW + DIFFICULTY_LAG
 


### PR DESCRIPTION
The v9 diff calculation was being applied to anyone who updated (even
before v9 was supposed to apply).  This rewrites it a bit to pass the
fork version into the diff algorithm then sets parameters appropriately.

(I'd like someone else to go through this really carefully, line-by-line, before merging it: if there's still a bug here it's going to cause more chaos).