### PR TITLE
Re-enable bulletproof transactions

### DIFF
--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -580,9 +580,7 @@ size_t estimate_tx_size(bool use_rct, int n_inputs, int mixin, int n_outputs, si
 
 uint8_t get_bulletproof_fork()
 {
-  // Don't send bulletproofs again until arqma v10.  v8 actually *did* send them, but the initial v9
-  // daemon accidentally refused to accept them, so we disable bulletproofs again until v10.
-  return 10;
+  return 8;
 }
 
 crypto::hash8 get_short_payment_id(const tools::wallet2::pending_tx &ptx, hw::device &hwdev)


### PR DESCRIPTION
Disabling bulletproofs caused problems with payment to multiple recipients (it appears to be caused by wallets trying to spend funds that originally was part of a bulletproof).

The 0.1.2.4 released forced bulletproofs off to try to remain compatible with 0.1.2.3, but this didn't work: there was already a bulletproof transaction on the network that caused 0.1.2.4 daemons to fork from 0.1.2.3 daemons.

Thus the current network essentially requires a 0.1.2.4 daemon to sync properly, and since 0.1.2.4 already support bulletproofs, there is no harm in turning them back on (they were, after all, running on the network before the 0.1.2.2 release all the way back to block 100).

There *is*, however, substantial benefits: this will allow pools (or regular wallets) to once again send transactions to multiple miners in a single transaction again, and moreover drops the transaction costs noticeably.