### PR TITLE
Ssl upgrade

### DIFF
--- a/contrib/epee/include/net/abstract_tcp_server2.h
+++ b/contrib/epee/include/net/abstract_tcp_server2.h
@@ -90,10 +90,10 @@ namespace net_utils
   public:
     typedef typename t_protocol_handler::connection_context t_connection_context;
 
-    struct shared_state : socket_stats
+    struct shared_state : connection_basic_shared_state
     {
       shared_state()
-        : socket_stats(), pfilter(nullptr), config()
+        : connection_basic_shared_state(), pfilter(nullptr), config()
       {}
 
       i_connection_filter* pfilter;
@@ -104,14 +104,12 @@ namespace net_utils
     explicit connection( boost::asio::io_service& io_service,
                          boost::shared_ptr<shared_state> state,
                          t_connection_type connection_type,
-                         epee::net_utils::ssl_support_t ssl_support,
-                         ssl_context_t &ssl_context);
+                         epee::net_utils::ssl_support_t ssl_support);
 
     explicit connection( boost::asio::ip::tcp::socket&& sock,
                          boost::shared_ptr<shared_state> state,
                          t_connection_type connection_type,
-                         epee::net_utils::ssl_support_t ssl_support,
-                         ssl_context_t &ssl_context);
+                         epee::net_utils::ssl_support_t ssl_support);
 
     virtual ~connection() noexcept(false);
 
@@ -226,8 +224,8 @@ namespace net_utils
     std::map<std::string, t_connection_type> server_type_map;
     void create_server_type_map();
 
-    bool init_server(uint32_t port, const std::string address = "0.0.0.0", epee::net_utils::ssl_support_t ssl_support = epee::net_utils::ssl_support_t::e_ssl_support_autodetect, const std::pair<std::string, std::string> &private_key_and_certificate_path = std::make_pair(std::string(), std::string()), const std::list<std::string> &allowed_certificates = {}, const std::vector<std::vector<uint8_t>> &allowed_fingerprints = {}, bool allow_any_cert = false);
-    bool init_server(const std::string port,  const std::string& address = "0.0.0.0", epee::net_utils::ssl_support_t ssl_support = epee::net_utils::ssl_support_t::e_ssl_support_autodetect, const std::pair<std::string, std::string> &private_key_and_certificate_path = std::make_pair(std::string(), std::string()), const std::list<std::string> &allowed_certificates = {}, const std::vector<std::vector<uint8_t>> &allowed_fingerprints = {}, bool allow_any_cert = false);
+    bool init_server(uint32_t port, const std::string address = "0.0.0.0", ssl_options_t ssl_options = ssl_support_t::autodetect);
+    bool init_server(const std::string port,  const std::string& address = "0.0.0.0", ssl_options_t ssl_options = ssl_support_t::autodetect);
 
     // Run the server's io_service loop.
     bool run_server(size_t threads_count, bool wait = true, const boost::thread::attributes& attrs = boost::thread::attributes());
@@ -255,11 +253,11 @@ namespace net_utils
       default_remote = std::move(remote);
     }
 
-    bool add_connection(t_connection_context& out, boost::asio::ip::tcp::socket&& sock, network_address real_remote, epee::net_utils::ssl_support_t ssl_support = epee::net_utils::ssl_support_t::e_ssl_support_autodetect);
-    try_connect_result_t try_connect(connection_ptr new_connection_l, const std::string& adr, const std::string& port, boost::asio::ip::tcp::socket &sock_, const boost::asio::ip::tcp::endpoint &remote_endpoint, const std::string &bind_ip, uint32_t conn_timeout, epee::net_utils::ssl_support_t ssl_support);
-    bool connect(const std::string& adr, const std::string& port, uint32_t conn_timeot, t_connection_context& cn, const std::string& bind_ip = "0.0.0.0", epee::net_utils::ssl_support_t ssl_support = epee::net_utils::ssl_support_t::e_ssl_support_autodetect);
+    bool add_connection(t_connection_context& out, boost::asio::ip::tcp::socket&& sock, network_address real_remote, epee::net_utils::ssl_support_t ssl_support = epee::net_utils::ssl_support_t::autodetect);
+    try_connect_result_t try_connect(connection_ptr new_connection_l, const std::string& adr, const std::string& port, boost::asio::ip::tcp::socket &sock_, const boost::asio::ip::tcp::endpoint &remote_endpoint, const std::string &bind_ip, uint32_t conn_timeout, ssl_support_t ssl_support);
+    bool connect(const std::string& adr, const std::string& port, uint32_t conn_timeot, t_connection_context& cn, const std::string& bind_ip = "0.0.0.0", ssl_support_t ssl_support = ssl_support_t::autodetect);
     template<class t_callback>
-    bool connect_async(const std::string& adr, const std::string& port, uint32_t conn_timeot, const t_callback &cb, const std::string& bind_ip = "0.0.0.0", epee::net_utils::ssl_support_t ssl_support = epee::net_utils::ssl_support_t::e_ssl_support_autodetect);
+    bool connect_async(const std::string& adr, const std::string& port, uint32_t conn_timeot, const t_callback &cb, const std::string& bind_ip = "0.0.0.0", ssl_support_t ssl_support = ssl_support_t::autodetect);
 
     typename t_protocol_handler::config_type& get_config_object()
     {
@@ -376,9 +374,6 @@ namespace net_utils
 
     boost::mutex connections_mutex;
     std::set<connection_ptr> connections_;
-
-    ssl_context_t m_ssl_context;
-    std::list<std::string> m_allowed_certificates;
 
   }; // class <>boosted_tcp_server
 

--- a/contrib/epee/include/net/abstract_tcp_server2.inl
+++ b/contrib/epee/include/net/abstract_tcp_server2.inl
@@ -79,10 +79,9 @@ PRAGMA_WARNING_DISABLE_VS(4355)
   connection<t_protocol_handler>::connection( boost::asio::io_service& io_service,
   	            boost::shared_ptr<shared_state> state,
                 t_connection_type connection_type,
-                epee::net_utils::ssl_support_t ssl_support,
-                ssl_context_t &ssl_context
+                epee::net_utils::ssl_support_t ssl_support
         )
-        : connection(boost::asio::ip::tcp::socket{io_service}, std::move(state), connection_type, ssl_support, ssl_context)
+        : connection(boost::asio::ip::tcp::socket{io_service}, std::move(state), connection_type, ssl_support)
   {
   }
 
@@ -90,11 +89,10 @@ PRAGMA_WARNING_DISABLE_VS(4355)
   connection<t_protocol_handler>::connection( boost::asio::ip::tcp::socket&& sock,
                 boost::shared_ptr<shared_state> state,
                 t_connection_type connection_type,
-                epee::net_utils::ssl_support_t ssl_support,
-                ssl_context_t &ssl_context
+                epee::net_utils::ssl_support_t ssl_support
         )
         :
-                connection_basic(std::move(sock), state, ssl_support, ssl_context),
+                connection_basic(std::move(sock), state, ssl_support),
                 m_protocol_handler(this, check_and_get(state).config, context),
                 m_connection_type( connection_type ),
                 m_throttle_speed_in("speed_in", "throttle_speed_in"),
@@ -166,7 +164,7 @@ PRAGMA_WARNING_DISABLE_VS(4355)
     const boost::uuids::uuid random_uuid = boost::uuids::random_generator()();
 
     context = t_connection_context{};
-    bool ssl = m_ssl_support == epee::net_utils::ssl_support_t::e_ssl_support_enabled;
+    bool ssl = m_ssl_support == ssl_support_t::enabled;
     context.set_details(random_uuid, std::move(real_remote), is_income, ssl);
 
     boost::system::error_code ec;
@@ -175,9 +173,9 @@ PRAGMA_WARNING_DISABLE_VS(4355)
 
     _dbg3("[sock " << socket_.native_handle() << "] new connection from " << print_connection_context_short(context) <<
           " to " << local_ep.address().to_string() << ':' << local_ep.port() <<
-          ", total sockets objects " << get_stats().sock_count);
+          ", total sockets objects " << get_state().sock_count);
 
-    if(static_cast<shared_state&>(get_stats()).pfilter && !static_cast<shared_state&>(get_stats()).pfilter->is_remote_host_allowed(context.m_remote_address))
+    if(static_cast<shared_state&>(get_state()).pfilter && !static_cast<shared_state&>(get_state()).pfilter->is_remote_host_allowed(context.m_remote_address))
     {
       _dbg2("[sock " << socket().native_handle() << "] host denied " << context.m_remote_address.host_str() << ", shutdowning connection");
       close();
@@ -193,7 +191,7 @@ PRAGMA_WARNING_DISABLE_VS(4355)
 
     // first read on the raw socket to detect SSL for the server
     buffer_ssl_init_fill = 0;
-    if (is_income && m_ssl_support != epee::net_utils::ssl_support_t::e_ssl_support_disabled)
+    if (is_income && m_ssl_support != ssl_support_t::disabled)
       socket().async_receive(boost::asio::buffer(buffer_),
         boost::asio::socket_base::message_peek,
         strand_.wrap(
@@ -434,21 +432,21 @@ PRAGMA_WARNING_DISABLE_VS(4355)
     }
 
     // detect SSL
-    if (m_ssl_support == epee::net_utils::ssl_support_t::e_ssl_support_autodetect)
+    if (m_ssl_support == ssl_support_t::autodetect)
     {
       if (is_ssl((const unsigned char*)buffer_.data(), buffer_ssl_init_fill))
       {
         MDEBUG("That looks like SSL");
-        m_ssl_support = epee::net_utils::ssl_support_t::e_ssl_support_enabled; // read/write to the SSL socket
+        m_ssl_support = ssl_support_t::enabled; // read/write to the SSL socket
       }
       else
       {
         MDEBUG("That does not look like SSL");
-        m_ssl_support = epee::net_utils::ssl_support_t::e_ssl_support_disabled; // read/write to the raw socket
+        m_ssl_support = ssl_support_t::disabled; // read/write to the raw socket
       }
     }
 
-    if (m_ssl_support == epee::net_utils::ssl_support_t::e_ssl_support_enabled)
+    if (m_ssl_support == ssl_support_t::enabled)
     {
       // Handshake
       if (!handshake(boost::asio::ssl::stream_base::server))
@@ -900,8 +898,7 @@ PRAGMA_WARNING_DISABLE_VS(4355)
       m_threads_count(0),
       m_thread_index(0),
                 m_connection_type( connection_type ),
-      new_connection_(),
-      m_ssl_context({boost::asio::ssl::context(boost::asio::ssl::context::tlsv12), {}})
+      new_connection_()
   {
       create_server_type_map();
       m_thread_name_prefix = "NET";
@@ -917,8 +914,7 @@ PRAGMA_WARNING_DISABLE_VS(4355)
       m_threads_count(0),
       m_thread_index(0),
                 m_connection_type(connection_type),
-      new_connection_(),
-      m_ssl_context({boost::asio::ssl::context(boost::asio::ssl::context::sslv23), {}})
+      new_connection_()
   {
       create_server_type_map();
       m_thread_name_prefix = "NET";
@@ -940,14 +936,14 @@ PRAGMA_WARNING_DISABLE_VS(4355)
   }
   //---------------------------------------------------------------------------------
   template<class t_protocol_handler>
-  bool boosted_tcp_server<t_protocol_handler>::init_server(uint32_t port, const std::string address, epee::net_utils::ssl_support_t ssl_support, const std::pair<std::string, std::string> &private_key_and_certificate_path, const std::list<std::string> &allowed_certificates, const std::vector<std::vector<uint8_t>> &allowed_fingerprints, bool allow_any_cert)
+  bool boosted_tcp_server<t_protocol_handler>::init_server(uint32_t port, const std::string address, ssl_options_t ssl_options)
   {
     TRY_ENTRY();
     m_stop_signal_sent = false;
     m_port = port;
     m_address = address;
-    if (ssl_support != epee::net_utils::ssl_support_t::e_ssl_support_disabled)
-      m_ssl_context = create_ssl_context(private_key_and_certificate_path, allowed_certificates, allowed_fingerprints, allow_any_cert);
+    if (ssl_options)
+      m_state->configure_ssl(std::move(ssl_options));
     // Open the acceptor with the option to reuse the address (i.e. SO_REUSEADDR).
     boost::asio::ip::tcp::resolver resolver(io_service_);
     boost::asio::ip::tcp::resolver::query query(address, boost::lexical_cast<std::string>(port), boost::asio::ip::tcp::resolver::query::canonical_name);
@@ -959,7 +955,7 @@ PRAGMA_WARNING_DISABLE_VS(4355)
     boost::asio::ip::tcp::endpoint binded_endpoint = acceptor_.local_endpoint();
     m_port = binded_endpoint.port();
     MDEBUG("start accept");
-    new_connection_.reset(new connection<t_protocol_handler>(io_service_, m_state, m_connection_type, ssl_support, m_ssl_context));
+    new_connection_.reset(new connection<t_protocol_handler>(io_service_, m_state, m_connection_type, m_state->ssl_options().support));
     acceptor_.async_accept(new_connection_->socket(),
       boost::bind(&boosted_tcp_server<t_protocol_handler>::handle_accept, this,
       boost::asio::placeholders::error));
@@ -981,7 +977,7 @@ PRAGMA_WARNING_DISABLE_VS(4355)
 PUSH_WARNINGS
 DISABLE_GCC_WARNING(maybe-uninitialized)
   template<class t_protocol_handler>
-  bool boosted_tcp_server<t_protocol_handler>::init_server(const std::string port, const std::string& address, epee::net_utils::ssl_support_t ssl_support, const std::pair<std::string, std::string> &private_key_and_certificate_path, const std::list<std::string> &allowed_certificates, const std::vector<std::vector<uint8_t>> &allowed_fingerprints, bool allow_any_cert)
+  bool boosted_tcp_server<t_protocol_handler>::init_server(const std::string port, const std::string& address, ssl_options_t ssl_options)
   {
     uint32_t p = 0;
 
@@ -989,7 +985,7 @@ DISABLE_GCC_WARNING(maybe-uninitialized)
       MERROR("Failed to convert port no = " << port);
       return false;
     }
-    return this->init_server(p, address, ssl_support, private_key_and_certificate_path, allowed_certificates, allowed_fingerprints, allow_any_cert);
+    return this->init_server(p, address, std::move(ssl_options));
   }
 POP_WARNINGS
   //---------------------------------------------------------------------------------
@@ -1157,15 +1153,15 @@ POP_WARNINGS
         const char *ssl_message = "unknown";
         switch (new_connection_->get_ssl_support())
         {
-          case epee::net_utils::ssl_support_t::e_ssl_support_disabled: ssl_message = "disabled"; break;
-          case epee::net_utils::ssl_support_t::e_ssl_support_enabled: ssl_message = "enabled"; break;
-          case epee::net_utils::ssl_support_t::e_ssl_support_autodetect: ssl_message = "autodetection"; break;
+          case ssl_support_t::disabled: ssl_message = "disabled"; break;
+          case ssl_support_t::enabled: ssl_message = "enabled"; break;
+          case ssl_support_t::autodetect: ssl_message = "autodetection"; break;
         }
         MDEBUG("New server for RPC connections, SSL " << ssl_message);
         new_connection_->setRpcStation(); // hopefully this is not needed actually
       }
       connection_ptr conn(std::move(new_connection_));
-      new_connection_.reset(new connection<t_protocol_handler>(io_service_, m_state , m_connection_type, conn->get_ssl_support(), m_ssl_context));
+      new_connection_.reset(new connection<t_protocol_handler>(io_service_, m_state, m_connection_type, conn->get_ssl_support()));
       acceptor_.async_accept(new_connection_->socket(), boost::bind(&boosted_tcp_server<t_protocol_handler>::handle_accept, this, boost::asio::placeholders::error));
 
       boost::asio::socket_base::keep_alive opt(true);
@@ -1198,16 +1194,16 @@ POP_WARNINGS
     assert(m_state != nullptr); // always set in constructor
     _erro("Some problems at accept: " << e.message() << ", connections_count = " << m_state->sock_count);
     misc_utils::sleep_no_w(100);
-    new_connection_.reset(new connection<t_protocol_handler>(io_service_, m_state, m_connection_type, new_connection_->get_ssl_support(), m_ssl_context));
+    new_connection_.reset(new connection<t_protocol_handler>(io_service_, m_state, m_connection_type, new_connection_->get_ssl_support()));
     acceptor_.async_accept(new_connection_->socket(), boost::bind(&boosted_tcp_server<t_protocol_handler>::handle_accept, this, boost::asio::placeholders::error));
   }
   //---------------------------------------------------------------------------------
   template<class t_protocol_handler>
-  bool boosted_tcp_server<t_protocol_handler>::add_connection(t_connection_context& out, boost::asio::ip::tcp::socket&& sock, network_address real_remote, epee::net_utils::ssl_support_t ssl_support)
+  bool boosted_tcp_server<t_protocol_handler>::add_connection(t_connection_context& out, boost::asio::ip::tcp::socket&& sock, network_address real_remote, ssl_support_t ssl_support)
   {
     if(std::addressof(get_io_service()) == std::addressof(sock.get_io_service()))
     {
-      connection_ptr conn(new connection<t_protocol_handler>(std::move(sock), m_state, m_connection_type, ssl_support, m_ssl_context));
+      connection_ptr conn(new connection<t_protocol_handler>(std::move(sock), m_state, m_connection_type, ssl_support));
       if(conn->start(false, 1 < m_threads_count, std::move(real_remote)))
       {
         conn->get_context(out);
@@ -1294,14 +1290,14 @@ POP_WARNINGS
 
     _dbg3("Connected success to " << adr << ':' << port);
 
-    const epee::net_utils::ssl_support_t ssl_support = new_connection_l->get_ssl_support();
-    if (ssl_support == epee::net_utils::ssl_support_t::e_ssl_support_enabled || ssl_support == epee::net_utils::ssl_support_t::e_ssl_support_autodetect)
+    const ssl_support_t ssl_support = new_connection_l->get_ssl_support();
+    if (ssl_support == ssl_support_t::enabled || ssl_support == ssl_support_t::autodetect)
     {
       // Handshake
       MDEBUG("Handshaking SSL...");
       if (!new_connection_l->handshake(boost::asio::ssl::stream_base::client))
       {
-        if (ssl_support == epee::net_utils::ssl_support_t::e_ssl_support_autodetect)
+        if (ssl_support == ssl_support_t::autodetect)
         {
           boost::system::error_code ignored_ec;
           sock_.shutdown(boost::asio::ip::tcp::socket::shutdown_both, ignored_ec);
@@ -1321,11 +1317,11 @@ POP_WARNINGS
   }
   //---------------------------------------------------------------------------------
   template<class t_protocol_handler>
-  bool boosted_tcp_server<t_protocol_handler>::connect(const std::string& adr, const std::string& port, uint32_t conn_timeout, t_connection_context& conn_context, const std::string& bind_ip, epee::net_utils::ssl_support_t ssl_support)
+  bool boosted_tcp_server<t_protocol_handler>::connect(const std::string& adr, const std::string& port, uint32_t conn_timeout, t_connection_context& conn_context, const std::string& bind_ip, ssl_support_t ssl_support)
   {
     TRY_ENTRY();
 
-    connection_ptr new_connection_l(new connection<t_protocol_handler>(io_service_, m_state, m_connection_type, ssl_support, m_ssl_context) );
+    connection_ptr new_connection_l(new connection<t_protocol_handler>(io_service_, m_state, m_connection_type, ssl_support) );
     connections_mutex.lock();
     connections_.insert(new_connection_l);
     MDEBUG("connections_ size now " << connections_.size());
@@ -1352,12 +1348,12 @@ POP_WARNINGS
     auto try_connect_result = try_connect(new_connection_l, adr, port, sock_, remote_endpoint, bind_ip, conn_timeout, ssl_support);
     if (try_connect_result == CONNECT_FAILURE)
       return false;
-    if (ssl_support == epee::net_utils::ssl_support_t::e_ssl_support_autodetect && try_connect_result == CONNECT_NO_SSL)
+    if (ssl_support == ssl_support_t::autodetect && try_connect_result == CONNECT_NO_SSL)
     {
       // we connected, but could not connect with SSL, try without
       MERROR("SSL handshake failed on an autodetect connection, reconnecting without SSL");
       new_connection_l->disable_ssl();
-      try_connect_result = try_connect(new_connection_l, adr, port, sock_, remote_endpoint, bind_ip, conn_timeout, epee::net_utils::ssl_support_t::e_ssl_support_disabled);
+      try_connect_result = try_connect(new_connection_l, adr, port, sock_, remote_endpoint, bind_ip, conn_timeout, ssl_support_t::disabled);
       if (try_connect_result != CONNECT_SUCCESS)
         return false;
     }
@@ -1385,10 +1381,10 @@ POP_WARNINGS
   }
   //---------------------------------------------------------------------------------
   template<class t_protocol_handler> template<class t_callback>
-  bool boosted_tcp_server<t_protocol_handler>::connect_async(const std::string& adr, const std::string& port, uint32_t conn_timeout, const t_callback &cb, const std::string& bind_ip, epee::net_utils::ssl_support_t ssl_support)
+  bool boosted_tcp_server<t_protocol_handler>::connect_async(const std::string& adr, const std::string& port, uint32_t conn_timeout, const t_callback &cb, const std::string& bind_ip, ssl_support_t ssl_support)
   {
     TRY_ENTRY();
-    connection_ptr new_connection_l(new connection<t_protocol_handler>(io_service_, m_state, m_connection_type, ssl_support, m_ssl_context) );
+    connection_ptr new_connection_l(new connection<t_protocol_handler>(io_service_, m_state, m_connection_type, ssl_support) );
     connections_mutex.lock();
     connections_.insert(new_connection_l);
     MDEBUG("connections_ size now " << connections_.size());

--- a/contrib/epee/include/net/connection_basic.hpp
+++ b/contrib/epee/include/net/connection_basic.hpp
@@ -58,14 +58,28 @@ namespace epee
 {
 namespace net_utils
 {
-  struct socket_stats
+  class connection_basic_shared_state
   {
-    socket_stats()
-      : sock_count(0), sock_number(0)
-    {}
-
+    ssl_options_t ssl_options_;
+  public:
+    boost::asio::ssl::context ssl_context;
     std::atomic<long> sock_count;
     std::atomic<long> sock_number;
+
+    connection_basic_shared_state()
+      : ssl_options_(ssl_support_t::disabled),
+        ssl_context(boost::asio::ssl::context::tlsv12),
+        sock_count(0),
+        sock_number(0)
+    {}
+
+    void configure_ssl(ssl_options_t src)
+    {
+      ssl_options_ = std::move(src);
+      ssl_context = ssl_options_.create_context();
+    }
+
+    const ssl_options_t& ssl_options() const noexcept { return ssl_options_; }
   };
 
   /************************************************************************/
@@ -84,9 +98,10 @@ class connection_basic_pimpl; // PIMPL for this class
   std::string to_string(t_connection_type type);
 
 class connection_basic { // not-templated base class for rapid developmet of some code parts
-  // beware of removing const, net_utils::connection is sketchily doing a cast to prevent storing ptr twice
-  const boost::shared_ptr<socket_stats> m_stats;
+                         // beware of removing const, net_utils::connection is sketchily doing a cast to prevent storing ptr twice
+                        const boost::shared_ptr<connection_basic_shared_state> m_state;
     public:
+
       std::unique_ptr< connection_basic_pimpl > mI; // my Implementation
 
       // moved here from orginal connecton<> - common member variables that do not depend on template in connection<>
@@ -98,34 +113,34 @@ class connection_basic { // not-templated base class for rapid developmet of som
   /// Strand to ensure the connection's handlers are not called concurrently.
   boost::asio::io_service::strand strand_;
   /// Socket for the connection.
-  ssl_context_t &m_ssl_context;
-  ssl_support_t m_ssl_support;
   boost::asio::ssl::stream<boost::asio::ip::tcp::socket> socket_;
+  ssl_support_t m_ssl_support;
 
     public:
       // first counter is the ++/-- count of current sockets, the other socket_number is only-increasing ++ number generator
-      connection_basic(boost::asio::ip::tcp::socket&& socket, boost::shared_ptr<socket_stats> stats, ssl_support_t ssl_support, ssl_context_t &ssl_context);
-      connection_basic(boost::asio::io_service &io_service, boost::shared_ptr<socket_stats> stats, ssl_support_t ssl_support, ssl_context_t &ssl_context);
+      connection_basic(boost::asio::ip::tcp::socket&& socket, boost::shared_ptr<connection_basic_shared_state> state, ssl_support_t ssl_support);
+		  connection_basic(boost::asio::io_service &io_service, boost::shared_ptr<connection_basic_shared_state> state, ssl_support_t ssl_support);
 
       virtual ~connection_basic() noexcept(false);
 
-      //! \return `socket_stats` object passed in construction (ptr never changes).
-      socket_stats& get_stats() noexcept { return *m_stats; /* verified in constructor */ }
-      connection_basic(boost::asio::io_service& io_service, std::atomic<long> &ref_sock_count, std::atomic<long> &sock_number, ssl_support_t ssl, ssl_context_t &ssl_context);
+      //! \return `shared_state` object passed in construction (ptr never changes).
+		  connection_basic_shared_state& get_state() noexcept { return *m_state; /* verified in constructor */ }
+		  connection_basic(boost::asio::io_service& io_service, std::atomic<long> &ref_sock_count, std::atomic<long> &sock_number, ssl_support_t ssl);
 
       boost::asio::ip::tcp::socket& socket() { return socket_.next_layer(); }
       ssl_support_t get_ssl_support() const { return m_ssl_support; }
-      void disable_ssl() { m_ssl_support = epee::net_utils::ssl_support_t::e_ssl_support_disabled; }
+      void disable_ssl() { m_ssl_support = ssl_support_t::disabled; }
 
       bool handshake(boost::asio::ssl::stream_base::handshake_type type)
       {
-        return ssl_handshake(socket_, type, m_ssl_context);
+        //m_state != nullptr verified in constructor
+        return m_state->ssl_options().handshake(socket_, type);
       }
 
       template<typename MutableBufferSequence, typename ReadHandler>
       void async_read_some(const MutableBufferSequence &buffers, ReadHandler &&handler)
       {
-        if (m_ssl_support == epee::net_utils::ssl_support_t::e_ssl_support_enabled)
+        if (m_ssl_support == ssl_support_t::enabled)
           socket_.async_read_some(buffers, std::forward<ReadHandler>(handler));
         else
           socket().async_read_some(buffers, std::forward<ReadHandler>(handler));
@@ -134,7 +149,7 @@ class connection_basic { // not-templated base class for rapid developmet of som
       template<typename ConstBufferSequence, typename WriteHandler>
       void async_write_some(const ConstBufferSequence &buffers, WriteHandler &&handler)
       {
-        if (m_ssl_support == epee::net_utils::ssl_support_t::e_ssl_support_enabled)
+        if (m_ssl_support == ssl_support_t::enabled)
           socket_.async_write_some(buffers, std::forward<WriteHandler>(handler));
         else
           socket().async_write_some(buffers, std::forward<WriteHandler>(handler));
@@ -143,7 +158,7 @@ class connection_basic { // not-templated base class for rapid developmet of som
       template<typename ConstBufferSequence, typename WriteHandler>
       void async_write(const ConstBufferSequence &buffers, WriteHandler &&handler)
       {
-        if (m_ssl_support == epee::net_utils::ssl_support_t::e_ssl_support_enabled)
+        if (m_ssl_support == ssl_support_t::enabled)
           boost::asio::async_write(socket_, buffers, std::forward<WriteHandler>(handler));
         else
           boost::asio::async_write(socket(), buffers, std::forward<WriteHandler>(handler));

--- a/contrib/epee/include/net/http_client.h
+++ b/contrib/epee/include/net/http_client.h
@@ -275,11 +275,6 @@ namespace net_utils
 			chunked_state m_chunked_state;
 			std::string m_chunked_cache;
 			critical_section m_lock;
-			epee::net_utils::ssl_support_t m_ssl_support;
-			std::pair<std::string, std::string> m_ssl_private_key_and_certificate_path;
-			std::list<std::string> m_ssl_allowed_certificates;
-			std::vector<std::vector<uint8_t>> m_ssl_allowed_fingerprints;
-			bool m_ssl_allow_any_cert;
 
 		public:
 			explicit http_simple_client_template()
@@ -297,34 +292,28 @@ namespace net_utils
 				, m_chunked_state()
 				, m_chunked_cache()
 				, m_lock()
-				, m_ssl_support(epee::net_utils::ssl_support_t::e_ssl_support_autodetect)
 			{}
 
 			const std::string &get_host() const { return m_host_buff; };
 			const std::string &get_port() const { return m_port; };
 
-			bool set_server(const std::string& address, boost::optional<login> user, epee::net_utils::ssl_support_t ssl_support = epee::net_utils::ssl_support_t::e_ssl_support_autodetect, const std::pair<std::string, std::string> &private_key_and_certificate_path = {}, const std::list<std::string> &allowed_ssl_certificates = {}, const std::vector<std::vector<uint8_t>> &allowed_ssl_fingerprints = {}, bool allow_any_cert = false)
+			bool set_server(const std::string& address, boost::optional<login> user, ssl_options_t ssl_options = ssl_support_t::autodetect)
 			{
 				http::url_content parsed{};
 				const bool r = parse_url(address, parsed);
 				CHECK_AND_ASSERT_MES(r, false, "failed to parse url: " << address);
-				set_server(std::move(parsed.host), std::to_string(parsed.port), std::move(user), ssl_support, private_key_and_certificate_path, allowed_ssl_certificates, allowed_ssl_fingerprints, allow_any_cert);
+				set_server(std::move(parsed.host), std::to_string(parsed.port), std::move(user), std::move(ssl_options));
 				return true;
 			}
 
-			void set_server(std::string host, std::string port, boost::optional<login> user, epee::net_utils::ssl_support_t ssl_support = epee::net_utils::ssl_support_t::e_ssl_support_autodetect, const std::pair<std::string, std::string> &private_key_and_certificate_path = {}, const std::list<std::string> &allowed_ssl_certificates = {}, const std::vector<std::vector<uint8_t>> &allowed_ssl_fingerprints = {}, bool allow_any_cert = false)
+			void set_server(std::string host, std::string port, boost::optional<login> user, ssl_options_t ssl_options = ssl_support_t::autodetect)
 			{
 				CRITICAL_REGION_LOCAL(m_lock);
 				disconnect();
 				m_host_buff = std::move(host);
 				m_port = std::move(port);
 				m_auth = user ? http_client_auth{std::move(*user)} : http_client_auth{};
-				m_ssl_support = ssl_support;
-				m_ssl_private_key_and_certificate_path = private_key_and_certificate_path;
-				m_ssl_allowed_certificates = allowed_ssl_certificates;
-				m_ssl_allowed_fingerprints = allowed_ssl_fingerprints;
-				m_ssl_allow_any_cert = allow_any_cert;
-				m_net_client.set_ssl(m_ssl_support, m_ssl_private_key_and_certificate_path, m_ssl_allowed_certificates, m_ssl_allowed_fingerprints, m_ssl_allow_any_cert);
+				m_net_client.set_ssl(std::move(ssl_options));
 			}
 
       bool connect(std::chrono::milliseconds timeout)

--- a/contrib/epee/include/net/http_server_impl_base.h
+++ b/contrib/epee/include/net/http_server_impl_base.h
@@ -59,11 +59,7 @@ namespace epee
     bool init(std::function<void(size_t, uint8_t*)> rng, const std::string& bind_port = "0", const std::string& bind_ip = "0.0.0.0",
       std::vector<std::string> access_control_origins = std::vector<std::string>(),
       boost::optional<net_utils::http::login> user = boost::none,
-      epee::net_utils::ssl_support_t ssl_support = epee::net_utils::ssl_support_t::e_ssl_support_autodetect,
-      const std::pair<std::string, std::string> &private_key_and_certificate_path = {},
-      std::list<std::string> allowed_certificates = {},
-      std::vector<std::vector<uint8_t>> allowed_fingerprints = {},
-      bool allow_any_cert = false)
+      net_utils::ssl_options_t ssl_options = net_utils::ssl_support_t::autodetect)
     {
 
       //set self as callback handler
@@ -80,7 +76,7 @@ namespace epee
       m_net_server.get_config_object().m_user = std::move(user);
 
       MGINFO("Binding on " << bind_ip << ":" << bind_port);
-      bool res = m_net_server.init_server(bind_port, bind_ip, ssl_support, private_key_and_certificate_path, std::move(allowed_certificates), std::move(allowed_fingerprints), allow_any_cert);
+      bool res = m_net_server.init_server(bind_port, bind_ip, std::move(ssl_options));
       if(!res)
       {
         LOG_ERROR("Failed to bind server");

--- a/contrib/epee/include/net/net_ssl.h
+++ b/contrib/epee/include/net/net_ssl.h
@@ -31,37 +31,102 @@
 
 #include <stdint.h>
 #include <string>
-#include <list>
+#include <vector>
 #include <boost/utility/string_ref.hpp>
 #include <boost/asio/ip/tcp.hpp>
 #include <boost/asio/ssl.hpp>
+#include <boost/system/error_code.hpp>
 
 namespace epee
 {
 namespace net_utils
 {
-	enum class ssl_support_t: uint8_t {
-		e_ssl_support_disabled,
-		e_ssl_support_enabled,
-		e_ssl_support_autodetect,
-	};
-
-	struct ssl_context_t
+	enum class ssl_support_t : uint8_t
 	{
-		boost::asio::ssl::context context;
-		std::list<std::string> allowed_certificates;
-		std::vector<std::vector<uint8_t>> allowed_fingerprints;
-		bool allow_any_cert;
-	};
+    disabled = 0,
+    enabled,
+    autodetect
+  };
+
+  enum class ssl_verification_t : uint8_t
+  {
+    none = 0,         //!< Do not verify peer.
+    system_ca,        //!< Verify peer via system ca only (do not inspect user certificates)
+    user_certificates //!< Verify peer via user certificate(s) only.
+  };
+
+  struct ssl_authentication_t
+  {
+    std::string private_key_path; //!< Private key used for authentication
+    std::string certificate_path; //!< Certificate used for authentication to peer.
+
+    //! Load `private_key_path` and `certificate_path` into `ssl_context`.
+    void use_ssl_certificate(boost::asio::ssl::context &ssl_context) const;
+  };
+
+  /*!
+    \note `verification != disabled && support == disabled` is currently
+      "allowed" via public interface but obviously invalid configuation.
+   */
+  class ssl_options_t
+  {
+    // force sorted behavior in private
+    std::vector<std::vector<std::uint8_t>> fingerprints_;
+
+  public:
+    std::string ca_path;
+    ssl_authentication_t auth;
+    ssl_support_t support;
+    ssl_verification_t verification;
+
+    //! Verification is set to system ca unless SSL is disabled.
+    ssl_options_t(ssl_support_t support)
+      : fingerprints_(),
+        ca_path(),
+        auth(),
+        support(support),
+        verification(support == ssl_support_t::disabled ? ssl_verification_t::none : ssl_verification_t::system_ca)
+    {}
+
+    //! Provide user fingerprints and/or ca path. Enables SSL and user_certificate verification
+    ssl_options_t(std::vector<std::vector<std::uint8_t>> fingerprints, std::string ca_path);
+
+    ssl_options_t(const ssl_options_t&) = default;
+    ssl_options_t(ssl_options_t&&) = default;
+
+    ssl_options_t& operator=(const ssl_options_t&) = default;
+    ssl_options_t& operator=(ssl_options_t&&) = default;
+
+    //! \return False iff ssl is disabled, otherwise true.
+    explicit operator bool() const noexcept { return support != ssl_support_t::disabled; }
+
+    //! Search against internal fingerprints. Always false if `behavior() != user_certificate_check`.
+    bool has_fingerprint(boost::asio::ssl::verify_context &ctx) const;
+
+    boost::asio::ssl::context create_context() const;
+
+    /*! \note If `this->support == autodetect && this->verification != none`,
+          then the handshake will not fail when peer verification fails. The
+          assumption is that a re-connect will be attempted, so a warning is
+          logged instead of failure.
+        \note It is strongly encouraged that clients using `system_ca`
+          verification provide a non-empty `host` for rfc2818 verification.
+        \param socket Used in SSL handshake and verification
+        \param type Client or server
+        \param host This parameter is only used when
+          `type == client && !host.empty()`. The value is sent to the server for
+          situations where multiple hostnames are being handled by a server. If
+          `verification == system_ca` the client also does a rfc2818 check to
+          ensure that the server certificate is to the provided hostname.
+        \return True if the SSL handshake completes with peer verification
+          settings. */
+    bool handshake(boost::asio::ssl::stream<boost::asio::ip::tcp::socket> &socket, boost::asio::ssl::stream_base::handshake_type type, const std::string& host = {}) const;
+  };
 
         // https://security.stackexchange.com/questions/34780/checking-client-hello-for-https-classification
 	constexpr size_t get_ssl_magic_size() { return 9; }
 	bool is_ssl(const unsigned char *data, size_t len);
-	ssl_context_t create_ssl_context(const std::pair<std::string, std::string> &private_key_and_certificate_path, std::list<std::string> allowed_certificates, std::vector<std::vector<uint8_t>> allowed_fingerprints, bool allow_any_cert);
-	void use_ssl_certificate(ssl_context_t &ssl_context, const std::pair<std::string, std::string> &private_key_and_certificate_path);
-	bool is_certificate_allowed(boost::asio::ssl::verify_context &ctx, const ssl_context_t &ssl_context);
-	bool ssl_handshake(boost::asio::ssl::stream<boost::asio::ip::tcp::socket> &socket, boost::asio::ssl::stream_base::handshake_type type, const epee::net_utils::ssl_context_t &ssl_context);
-    bool ssl_support_from_string(ssl_support_t &ssl, boost::string_ref s);
+	bool ssl_support_from_string(ssl_support_t &ssl, boost::string_ref s);
 }
 }
 

--- a/contrib/epee/src/connection_basic.cpp
+++ b/contrib/epee/src/connection_basic.cpp
@@ -59,6 +59,15 @@ namespace epee
 namespace net_utils
 {
 
+namespace
+{
+  boost::asio::ssl::context& get_context(connection_basic_shared_state* state)
+  {
+		CHECK_AND_ASSERT_THROW_MES(state != nullptr, "state shared_ptr cannot be null");
+		return state->ssl_context;
+	}
+}
+
   std::string to_string(t_connection_type type)
   {
 	  if (type == e_connection_type_NET)
@@ -113,54 +122,52 @@ connection_basic_pimpl::connection_basic_pimpl(const std::string &name) : m_thro
 int connection_basic_pimpl::m_default_tos;
 
 // methods:
-connection_basic::connection_basic(boost::asio::ip::tcp::socket&& sock, boost::shared_ptr<socket_stats> stats, ssl_support_t ssl_support, ssl_context_t &ssl_context)
-	: m_stats(std::move(stats)),
-      mI( new connection_basic_pimpl("peer") ),
-      strand_(sock.get_io_service()),
-      socket_(sock.get_io_service(), ssl_context.context),
-      m_want_close_connection(false),
-      m_was_shutdown(false),
-      m_ssl_support(ssl_support),
-      m_ssl_context(ssl_context)
+connection_basic::connection_basic(boost::asio::ip::tcp::socket&& sock, boost::shared_ptr<connection_basic_shared_state> state, ssl_support_t ssl_support)
+	: m_state(std::move(state)),
+    mI( new connection_basic_pimpl("peer") ),
+    strand_(sock.get_io_service()),
+    socket_(sock.get_io_service(), get_context(m_state.get())),
+    m_want_close_connection(false),
+    m_was_shutdown(false),
+    m_ssl_support(ssl_support)
 {
     // add nullptr checks if removed
-    CHECK_AND_ASSERT_THROW_MES(bool(m_stats), "stats shared_ptr cannot be null");
+    assert(m_state != nullptr); // release runtime check in get_context
 
     socket_.next_layer() = std::move(sock);
 
-    ++(m_stats->sock_count); // increase the global counter
-    mI->m_peer_number = m_stats->sock_number.fetch_add(1); // use, and increase the generated number
+    ++(m_state->sock_count); // increase the global counter
+    mI->m_peer_number = m_state->sock_number.fetch_add(1); // use, and increase the generated number
 
     std::string remote_addr_str = "?";
     try { boost::system::error_code e; remote_addr_str = socket().remote_endpoint(e).address().to_string(); } catch(...){} ;
 
-    _note("Spawned connection #"<<mI->m_peer_number<<" to " << remote_addr_str << " currently we have sockets count:" << m_stats->sock_count);
+    _note("Spawned connection #"<<mI->m_peer_number<<" to " << remote_addr_str << " currently we have sockets count:" << m_state->sock_count);
 }
 
-connection_basic::connection_basic(boost::asio::io_service &io_service, boost::shared_ptr<socket_stats> stats, ssl_support_t ssl_support, ssl_context_t &ssl_context)
-	: m_stats(std::move(stats)),
-      mI( new connection_basic_pimpl("peer") ),
-      strand_(io_service),
-      socket_(io_service, ssl_context.context),
-      m_want_close_connection(false),
-      m_was_shutdown(false),
-      m_ssl_support(ssl_support),
-      m_ssl_context(ssl_context)
+connection_basic::connection_basic(boost::asio::io_service &io_service, boost::shared_ptr<connection_basic_shared_state> state, ssl_support_t ssl_support)
+	: m_state(std::move(state)),
+    mI( new connection_basic_pimpl("peer") ),
+    strand_(io_service),
+    socket_(io_service, get_context(m_state.get())),
+    m_want_close_connection(false),
+    m_was_shutdown(false),
+    m_ssl_support(ssl_support)
 {
     // add nullptr checks if removed
-    CHECK_AND_ASSERT_THROW_MES(bool(m_stats), "stats shared_ptr cannot be null");
+    assert(m_state != nullptr); // release runtime check in get_context
 
-    ++(m_stats->sock_count); // increase the global counter
-    mI->m_peer_number = m_stats->sock_number.fetch_add(1); // use, and increase the generated number
+    ++(m_state->sock_count); // increase the global counter
+    mI->m_peer_number = m_state->sock_number.fetch_add(1); // use, and increase the generated number
 
     std::string remote_addr_str = "?";
     try { boost::system::error_code e; remote_addr_str = socket().remote_endpoint(e).address().to_string(); } catch(...){} ;
 
-    _note("Spawned connection # " << mI->m_peer_number << " to " << remote_addr_str << " currently we have sockets count:" << m_stats->sock_count);
+    _note("Spawned connection # " << mI->m_peer_number << " to " << remote_addr_str << " currently we have sockets count:" << m_state->sock_count);
 }
 
 connection_basic::~connection_basic() noexcept(false) {
-  --(m_stats->sock_count);
+  --(m_state->sock_count);
 
 	std::string remote_addr_str = "?";
 	try { boost::system::error_code e; remote_addr_str = socket().remote_endpoint(e).address().to_string(); } catch(...){} ;

--- a/contrib/epee/src/net_ssl.cpp
+++ b/contrib/epee/src/net_ssl.cpp
@@ -63,12 +63,28 @@ namespace
   };
   using openssl_pkey = std::unique_ptr<EVP_PKEY, openssl_pkey_free>;
 
+  boost::system::error_code load_ca_file(boost::asio::ssl::context& ctx, const std::string& path)
+  {
+    SSL_CTX* const ssl_ctx = ctx.native_handle(); // could be moved from context
+    if (ssl_ctx == nullptr)
+      return {boost::asio::error::invalid_argument};
+
+    if (!SSL_CTX_load_verify_locations(ssl_ctx, path.c_str(), nullptr))
+    {
+      return boost::system::error_code{
+        int(::ERR_get_error()), boost::asio::error::get_ssl_category()
+      };
+    }
+    return boost::system::error_code{};
+  }
+
 }
 
 namespace epee
 {
 namespace net_utils
 {
+
 
 // https://stackoverflow.com/questions/256405/programmatically-create-x509-certificate-using-openssl
 bool create_ssl_certificate(EVP_PKEY *&pkey, X509 *&cert)
@@ -125,22 +141,34 @@ bool create_ssl_certificate(EVP_PKEY *&pkey, X509 *&cert)
   return true;
 }
 
-ssl_context_t create_ssl_context(const std::pair<std::string, std::string> &private_key_and_certificate_path, std::list<std::string> allowed_certificates, std::vector<std::vector<uint8_t>> allowed_fingerprints, bool allow_any_cert)
+ssl_options_t::ssl_options_t(std::vector<std::vector<std::uint8_t>> fingerprints, std::string ca_path)
+  : fingerprints_(std::move(fingerprints)),
+    ca_path(std::move(ca_path)),
+    auth(),
+    support(ssl_support_t::enabled),
+    verification(ssl_verification_t::user_certificates)
 {
-  ssl_context_t ssl_context{boost::asio::ssl::context(boost::asio::ssl::context::tlsv12), std::move(allowed_certificates), std::move(allowed_fingerprints)};
+  std::sort(fingerprints_.begin(), fingerprints_.end());
+}
+
+boost::asio::ssl::context ssl_options_t::create_context() const
+{
+  boost::asio::ssl::context ssl_context{boost::asio::ssl::context::tlsv12};
+  if (!bool(*this))
+    return ssl_context;
 
   // only allow tls v1.2 and up
-  ssl_context.context.set_options(boost::asio::ssl::context::default_workarounds);
-  ssl_context.context.set_options(boost::asio::ssl::context::no_sslv2);
-  ssl_context.context.set_options(boost::asio::ssl::context::no_sslv3);
-  ssl_context.context.set_options(boost::asio::ssl::context::no_tlsv1);
-  ssl_context.context.set_options(boost::asio::ssl::context::no_tlsv1_1);
+  ssl_context.set_options(boost::asio::ssl::context::default_workarounds);
+  ssl_context.set_options(boost::asio::ssl::context::no_sslv2);
+  ssl_context.set_options(boost::asio::ssl::context::no_sslv3);
+  ssl_context.set_options(boost::asio::ssl::context::no_tlsv1);
+  ssl_context.set_options(boost::asio::ssl::context::no_tlsv1_1);
 
   // only allow a select handful of tls v1.3 and v1.2 ciphers to be used
-  SSL_CTX_set_cipher_list(ssl_context.context.native_handle(), "ECDHE-ECDSA-CHACHA20-POLY1305-SHA256:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-CHACHA20-POLY1305");
+  SSL_CTX_set_cipher_list(ssl_context.native_handle(), "ECDHE-ECDSA-CHACHA20-POLY1305-SHA256:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-CHACHA20-POLY1305");
 
   // set options on the SSL context for added security
-  SSL_CTX *ctx = ssl_context.context.native_handle();
+  SSL_CTX *ctx = ssl_context.native_handle();
   CHECK_AND_ASSERT_THROW_MES(ctx, "Failed to get SSL context");
   SSL_CTX_clear_options(ctx, SSL_OP_LEGACY_SERVER_CONNECT); // SSL_CTX_SET_OPTIONS(3)
   SSL_CTX_set_session_cache_mode(ctx, SSL_SESS_CACHE_OFF); // https://stackoverflow.com/questions/22378442
@@ -156,10 +184,26 @@ ssl_context_t create_ssl_context(const std::pair<std::string, std::string> &priv
 #ifdef SSL_OP_NO_COMPRESSION
   SSL_CTX_set_options(ctx, SSL_OP_NO_COMPRESSION);
 #endif
-  ssl_context.context.set_default_verify_paths();
 
-  CHECK_AND_ASSERT_THROW_MES(private_key_and_certificate_path.first.empty() == private_key_and_certificate_path.second.empty(), "private key and certificate must be either both given or both empty");
-  if (private_key_and_certificate_path.second.empty())
+  switch (verification)
+  {
+    case ssl_verification_t::system_ca:
+      ssl_context.set_default_verify_paths();
+      break;
+    case ssl_verification_t::user_certificates:
+      if (!ca_path.empty())
+      {
+        const boost::system::error_code err = load_ca_file(ssl_context, ca_path);
+        if (err)
+          throw boost::system::system_error{err, "Failed to load user CA file at " + ca_path};
+      }
+      break;
+    default:
+      break;
+  }
+
+  CHECK_AND_ASSERT_THROW_MES(auth.private_key_path.empty() == auth.certificate_path.empty(), "private key and certificate must be either both given or both empty");
+  if (auth.private_key_path.empty())
   {
     EVP_PKEY *pkey;
     X509 *cert;
@@ -169,19 +213,15 @@ ssl_context_t create_ssl_context(const std::pair<std::string, std::string> &priv
     EVP_PKEY_free(pkey);
   }
   else
-  {
-    ssl_context.context.use_private_key_file(private_key_and_certificate_path.first, boost::asio::ssl::context::pem);
-    ssl_context.context.use_certificate_file(private_key_and_certificate_path.second, boost::asio::ssl::context::pem);
-  }
-  ssl_context.allow_any_cert = allow_any_cert;
+    auth.use_ssl_certificate(ssl_context);
 
   return ssl_context;
 }
 
-void use_ssl_certificate(ssl_context_t &ssl_context, const std::pair<std::string, std::string> &private_key_and_certificate_path)
+void ssl_authentication_t::use_ssl_certificate(boost::asio::ssl::context &ssl_context) const
 {
-  ssl_context.context.use_private_key_file(private_key_and_certificate_path.first, boost::asio::ssl::context::pem);
-  ssl_context.context.use_certificate_file(private_key_and_certificate_path.second, boost::asio::ssl::context::pem);
+  ssl_context.use_private_key_file(private_key_path, boost::asio::ssl::context::pem);
+  ssl_context.use_certificate_chain_file(certificate_path);
 }
 
 bool is_ssl(const unsigned char *data, size_t len)
@@ -204,23 +244,23 @@ bool is_ssl(const unsigned char *data, size_t len)
   return false;
 }
 
-bool is_certificate_allowed(boost::asio::ssl::verify_context &ctx, const ssl_context_t &ssl_context)
+bool ssl_options_t::has_fingerprint(boost::asio::ssl::verify_context &ctx) const
 {
-  X509_STORE_CTX *sctx = ctx.native_handle();
-  if (!sctx)
-  {
-    MERROR("Error getting verify_context handle");
-    return false;
-  }
-  X509 *cert =X509_STORE_CTX_get_current_cert(sctx);
-  if (!cert)
-  {
-    MERROR("No certificate found in verify_context");
-    return false;
-  }
-
   // can we check the certificate against a list of fingerprints?
-  if (!ssl_context.allowed_fingerprints.empty()) {
+  if (!fingerprints_.empty()) {
+    X509_STORE_CTX *sctx = ctx.native_handle();
+    if (!sctx)
+    {
+      MERROR("Error getting verify_context handle");
+      return false;
+    }
+    X509 *cert =X509_STORE_CTX_get_current_cert(sctx);
+    if (!cert)
+    {
+      MERROR("No certificate found in verify_context");
+      return false;
+    }
+
     // buffer for the certificate digest and the size of the result
     std::vector<uint8_t> digest(EVP_MAX_MD_SIZE);
     unsigned int size{ 0 };
@@ -234,74 +274,62 @@ bool is_certificate_allowed(boost::asio::ssl::verify_context &ctx, const ssl_con
     // strip unnecessary bytes from the digest
     digest.resize(size);
 
-    // is the certificate fingerprint inside the list of allowed fingerprints?
-    if (std::find(ssl_context.allowed_fingerprints.begin(), ssl_context.allowed_fingerprints.end(), digest) != ssl_context.allowed_fingerprints.end())
-      return true;
+    return std::binary_search(fingerprints_.begin(), fingerprints_.end(), digest);
   }
 
-  if (!ssl_context.allowed_certificates.empty()) {
-    BIO *bio_cert = BIO_new(BIO_s_mem());
-    bool success = PEM_write_bio_X509(bio_cert, cert);
-    if (!success)
-    {
-      BIO_free(bio_cert);
-      MERROR("Failed to print certificate");
-      return false;
-    }
-    BUF_MEM *buf = NULL;
-    BIO_get_mem_ptr(bio_cert, &buf);
-    if (!buf || !buf->data || !buf->length)
-    {
-      BIO_free(bio_cert);
-      MERROR("Failed to write certificate: " << ERR_get_error());
-      return false;
-    }
-    std::string certificate(std::string(buf->data, buf->length));
-    BIO_free(bio_cert);
-    if (std::find(ssl_context.allowed_certificates.begin(), ssl_context.allowed_certificates.end(), certificate) != ssl_context.allowed_certificates.end())
-      return true;
-  }
-
-  // if either checklist is non-empty we must have failed it
-  return ssl_context.allowed_fingerprints.empty() && ssl_context.allowed_certificates.empty();
+  return false;
 }
 
-bool ssl_handshake(boost::asio::ssl::stream<boost::asio::ip::tcp::socket> &socket, boost::asio::ssl::stream_base::handshake_type type, const epee::net_utils::ssl_context_t &ssl_context)
+bool ssl_options_t::handshake(boost::asio::ssl::stream<boost::asio::ip::tcp::socket> &socket, boost::asio::ssl::stream_base::handshake_type type, const std::string& host) const
 {
-  bool verified = false;
   socket.next_layer().set_option(boost::asio::ip::tcp::no_delay(true));
-  socket.set_verify_mode(boost::asio::ssl::verify_peer);
-  socket.set_verify_callback([&](bool preverified, boost::asio::ssl::verify_context &ctx)
+
+  /* Using system-wide CA store for client verification is funky - there is
+     no expected hostname for server to verify against. If server doesn't have
+     specific whitelisted certificates for client, don't require client to
+     send certificate at all. */
+  const bool no_verification = verification == ssl_verification_t::none || (type == boost::asio::ssl::stream_base::server && fingerprints_.empty() && ca_path.empty());
+
+  /* According to OpenSSL documentation (and SSL specifications), server must
+     always send certificate unless "anonymous" cipher mode is used which are
+     disabled by default. Either way, the certificate is never inspected. */
+
+  if (no_verification)
+    socket.set_verify_mode(boost::asio::ssl::verify_none);
+  else
   {
-    if (!preverified)
+    socket.set_verify_mode(boost::asio::ssl::verify_peer | boost::asio::ssl::verify_fail_if_no_peer_cert);
+
+    // in case server is doing "virtual" domains, set hostname
+    SSL* const ssl_ctx = socket.native_handle();
+    if (type == boost::asio::ssl::stream_base::client && !host.empty() && ssl_ctx)
+      SSL_set_tlsext_host_name(ssl_ctx, host.c_str());
+
+    socket.set_verify_callback([&](const bool preverified, boost::asio::ssl::verify_context &ctx)
     {
-      const int err = X509_STORE_CTX_get_error(ctx.native_handle());
-      const int depth = X509_STORE_CTX_get_error_depth(ctx.native_handle());
-      if (err != X509_V_ERR_DEPTH_ZERO_SELF_SIGNED_CERT || depth != 0)
+      // preverified means it passed system or user CA check. System CA is never loaded
+      // when fingerprints are whitelisted.
+      const bool verified = preverified && (verification != ssl_verification_t::system_ca || host.empty() || boost::asio::ssl::rfc2818_verification(host)(preverified, ctx));
+
+      if (!verified && !has_fingerprint(ctx))
       {
-        MERROR("Invalid SSL certificate, error " << err << " at depth " << depth << ", connection dropped");
-        return false;
+        // autodetect will reconnect without SSL - warn and keep connection encrypted
+        if (support != ssl_support_t::autodetect)
+        {
+          MERROR("SSL certificate is not in the allowed list, connection droppped");
+          return false;
+        }
+        MWARNING("SSL peer has not been verified");
       }
-    }
-    if (!ssl_context.allow_any_cert && !is_certificate_allowed(ctx, ssl_context))
-    {
-      MERROR("Certificate is not in the allowed list, connection droppped");
-      return false;
-    }
-    verified = true;
-    return true;
-  });
+      return true;
+    });
+  }
 
   boost::system::error_code ec;
   socket.handshake(type, ec);
   if (ec)
   {
-    MERROR("handshake failed, connection dropped: " << ec.message());
-    return false;
-  }
-  if (!ssl_context.allow_any_cert && !verified)
-  {
-    MERROR("Peer did not provide a certificate in the allowed list, connection dropped");
+    MERROR("SSL handshake failed, connection dropped: " << ec.message());
     return false;
   }
   MDEBUG("SSL handshake success");
@@ -311,11 +339,11 @@ bool ssl_handshake(boost::asio::ssl::stream<boost::asio::ip::tcp::socket> &socke
 bool ssl_support_from_string(ssl_support_t &ssl, boost::string_ref s)
 {
   if (s == "enabled")
-    ssl = epee::net_utils::ssl_support_t::e_ssl_support_enabled;
+    ssl = epee::net_utils::ssl_support_t::enabled;
   else if (s == "disabled")
-    ssl = epee::net_utils::ssl_support_t::e_ssl_support_disabled;
+    ssl = epee::net_utils::ssl_support_t::disabled;
   else if (s == "autodetect")
-    ssl = epee::net_utils::ssl_support_t::e_ssl_support_autodetect;
+    ssl = epee::net_utils::ssl_support_t::autodetect;
   else
     return false;
   return true;

--- a/src/common/download.cpp
+++ b/src/common/download.cpp
@@ -180,8 +180,8 @@ namespace tools
 
       lock.unlock();
 
-      epee::net_utils::ssl_support_t ssl = u_c.schema == "https" ? epee::net_utils::ssl_support_t::e_ssl_support_enabled : epee::net_utils::ssl_support_t::e_ssl_support_disabled;
-      uint16_t port = u_c.port ? u_c.port : ssl == epee::net_utils::ssl_support_t::e_ssl_support_enabled ? 443 : 80;
+      epee::net_utils::ssl_support_t ssl = u_c.schema == "https" ? epee::net_utils::ssl_support_t::enabled : epee::net_utils::ssl_support_t::disabled;
+      uint16_t port = u_c.port ? u_c.port : ssl == epee::net_utils::ssl_support_t::enabled ? 443 : 80;
       MDEBUG("Connecting to " << u_c.host << ":" << port);
       client.set_server(u_c.host, std::to_string(port), boost::none, ssl);
       if (!client.connect(std::chrono::seconds(30)))

--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -674,7 +674,7 @@ namespace nodetool
     std::transform(p2p_ssl_allowed_fingerprints.begin(), p2p_ssl_allowed_fingerprints.end(), allowed_fingerprints.begin(), epee::from_hex::vector);
 
     //try to bind
-    m_ssl_support = epee::net_utils::ssl_support_t::e_ssl_support_disabled;
+    m_ssl_support = epee::net_utils::ssl_support_t::disabled;
     for (auto& zone : m_network_zones)
     {
       zone.second.m_net_server.get_config_object().set_handler(this);
@@ -684,7 +684,7 @@ namespace nodetool
       {
         zone.second.m_net_server.set_connection_filter(this);
         MINFO("Binding on " << zone.second.m_bind_ip << ":" << zone.second.m_port);
-        res = zone.second.m_net_server.init_server(zone.second.m_port, zone.second.m_bind_ip, epee::net_utils::ssl_support_t::e_ssl_support_disabled);
+        res = zone.second.m_net_server.init_server(zone.second.m_port, zone.second.m_bind_ip, epee::net_utils::ssl_support_t::disabled);
         CHECK_AND_ASSERT_MES(res, false, "Failed to bind server");
       }
     }

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -79,7 +79,7 @@ namespace cryptonote
     command_line::add_arg(desc, arg_rpc_ssl);
     command_line::add_arg(desc, arg_rpc_ssl_private_key);
     command_line::add_arg(desc, arg_rpc_ssl_certificate);
-    command_line::add_arg(desc, arg_rpc_ssl_allowed_certificates);
+    command_line::add_arg(desc, arg_rpc_ssl_ca_certificates);
     command_line::add_arg(desc, arg_rpc_ssl_allowed_fingerprints);
     command_line::add_arg(desc, arg_rpc_ssl_allow_any_cert);
     command_line::add_arg(desc, arg_bootstrap_daemon_address);
@@ -118,11 +118,11 @@ namespace cryptonote
         epee::net_utils::http::login login;
         login.username = bootstrap_daemon_login.substr(0, loc);
         login.password = bootstrap_daemon_login.substr(loc + 1);
-        m_http_client.set_server(m_bootstrap_daemon_address, login, epee::net_utils::ssl_support_t::e_ssl_support_autodetect);
+        m_http_client.set_server(m_bootstrap_daemon_address, login, epee::net_utils::ssl_support_t::autodetect);
       }
       else
       {
-        m_http_client.set_server(m_bootstrap_daemon_address, boost::none, epee::net_utils::ssl_support_t::e_ssl_support_autodetect);
+        m_http_client.set_server(m_bootstrap_daemon_address, boost::none, epee::net_utils::ssl_support_t::autodetect);
       }
       m_should_use_bootstrap_daemon = true;
     }
@@ -137,36 +137,38 @@ namespace cryptonote
     if (rpc_config->login)
       http_login.emplace(std::move(rpc_config->login->username), std::move(rpc_config->login->password).password());
 
-    epee::net_utils::ssl_support_t ssl_support;
-    const std::string ssl = command_line::get_arg(vm, arg_rpc_ssl);
-    if (!epee::net_utils::ssl_support_from_string(ssl_support, ssl))
+    epee::net_utils::ssl_options_t ssl_options = epee::net_utils::ssl_support_t::autodetect;
+    if (command_line::get_arg(vm, arg_rpc_ssl_allow_any_cert))
+      ssl_options.verification = epee::net_utils::ssl_verification_t::none;
+    else
     {
-      MFATAL("Invalid RPC SSL support: " << ssl);
-      return false;
+      std::string ssl_ca_path = command_line::get_arg(vm, arg_rpc_ssl_ca_certificates);
+      const std::vector<std::string> ssl_allowed_fingerprint_strings = command_line::get_arg(vm, arg_rpc_ssl_allowed_fingerprints);
+      std::vector<std::vector<uint8_t>> ssl_allowed_fingerprints{ ssl_allowed_fingerprint_strings.size() };
+      std::transform(ssl_allowed_fingerprint_strings.begin(), ssl_allowed_fingerprint_strings.end(), ssl_allowed_fingerprints.begin(), epee::from_hex::vector);
+
+      if (!ssl_ca_path.empty() || !ssl_allowed_fingerprints.empty())
+        ssl_options = epee::net_utils::ssl_options_t{std::move(ssl_allowed_fingerprints), std::move(ssl_ca_path)};
     }
-    const std::string ssl_private_key = command_line::get_arg(vm, arg_rpc_ssl_private_key);
-    const std::string ssl_certificate = command_line::get_arg(vm, arg_rpc_ssl_certificate);
-    const std::vector<std::string> ssl_allowed_certificate_paths = command_line::get_arg(vm, arg_rpc_ssl_allowed_certificates);
-    std::list<std::string> ssl_allowed_certificates;
-    for (const std::string &path: ssl_allowed_certificate_paths)
+
+    ssl_options.auth = epee::net_utils::ssl_authentication_t{
+      command_line::get_arg(vm, arg_rpc_ssl_private_key), command_line::get_arg(vm, arg_rpc_ssl_certificate)
+    };
+
+    // user specified CA file or fingeprints implies enabled SSL by default
+    if (ssl_options.verification != epee::net_utils::ssl_verification_t::user_certificates || !command_line::is_arg_defaulted(vm, arg_rpc_ssl)
     {
-      ssl_allowed_certificates.push_back({});
-      if (!epee::file_io_utils::load_file_to_string(path, ssl_allowed_certificates.back()))
+      const std::string ssl = command_line::get_arg(vm, arg_rpc_ssl);
+      if (!epee::net_utils::ssl_support_from_string(ssl_options.support, ssl))
       {
-        MERROR("Failed to load certificate: " << path);
-        ssl_allowed_certificates.back() = std::string();
+        MFATAL("Invalid RPC SSL support: " << ssl);
+        return false;
       }
     }
 
-    const std::vector<std::string> ssl_allowed_fingerprint_strings = command_line::get_arg(vm, arg_rpc_ssl_allowed_fingerprints);
-    std::vector<std::vector<uint8_t>> ssl_allowed_fingerprints{ ssl_allowed_fingerprint_strings.size() };
-    std::transform(ssl_allowed_fingerprint_strings.begin(), ssl_allowed_fingerprint_strings.end(), ssl_allowed_fingerprints.begin(), epee::from_hex::vector);
-    const bool ssl_allow_any_cert = command_line::get_arg(vm, arg_rpc_ssl_allow_any_cert);
-
     auto rng = [](size_t len, uint8_t *ptr){ return crypto::rand(len, ptr); };
     return epee::http_server_impl_base<core_rpc_server, connection_context>::init(
-      rng, std::move(port), std::move(rpc_config->bind_ip), std::move(rpc_config->access_control_origins), std::move(http_login),
-      ssl_support, std::make_pair(ssl_private_key, ssl_certificate), std::move(ssl_allowed_certificates), std::move(ssl_allowed_fingerprints), ssl_allow_any_cert
+      rng, std::move(port), std::move(rpc_config->bind_ip), std::move(rpc_config->access_control_origins), std::move(http_login), std::move(ssl_options)
     );
   }
   //------------------------------------------------------------------------------------------------------------------------------
@@ -2359,9 +2361,9 @@ namespace cryptonote
     , ""
     };
 
-  const command_line::arg_descriptor<std::vector<std::string>> core_rpc_server::arg_rpc_ssl_allowed_certificates = {
-      "rpc-ssl-allowed-certificates"
-    , "Path to list with allowed peers Certificates in PEM format. If empty it will allow all"
+  const command_line::arg_descriptor<std::string> core_rpc_server::arg_rpc_ssl_ca_certificates = {
+      "rpc-ssl-ca-certificates"
+    , "Path to file containing concatenated PEM format certificate(s) to replace system CA(s)."
     };
 
   const command_line::arg_descriptor<std::vector<std::string>> core_rpc_server::arg_rpc_ssl_allowed_fingerprints = {
@@ -2371,7 +2373,7 @@ namespace cryptonote
 
   const command_line::arg_descriptor<bool> core_rpc_server::arg_rpc_ssl_allow_any_cert = {
       "rpc-ssl-allow-any-cert"
-    , "Allow any Certificate used by peer, rather than just those on the allowed list"
+    , "Allow any Certificate used by peer."
     , false
     };
 

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -163,12 +163,11 @@ namespace cryptonote
       {
         MFATAL("Invalid RPC SSL support: " << ssl);
         return false;
-      }
+      };
     }
 
     auto rng = [](size_t len, uint8_t *ptr){ return crypto::rand(len, ptr); };
-    return epee::http_server_impl_base<core_rpc_server, connection_context>::init(
-      rng, std::move(port), std::move(rpc_config->bind_ip), std::move(rpc_config->access_control_origins), std::move(http_login), std::move(ssl_options)
+    return epee::http_server_impl_base<core_rpc_server, connection_context>::init(rng, std::move(port), std::move(rpc_config->bind_ip), std::move(rpc_config->access_control_origins), std::move(http_login), std::move(ssl_options)
     );
   }
   //------------------------------------------------------------------------------------------------------------------------------

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -156,14 +156,14 @@ namespace cryptonote
     };
 
     // user specified CA file or fingeprints implies enabled SSL by default
-    if (ssl_options.verification != epee::net_utils::ssl_verification_t::user_certificates || !command_line::is_arg_defaulted(vm, arg_rpc_ssl)
+    if (ssl_options.verification != epee::net_utils::ssl_verification_t::user_certificates || !command_line::is_arg_defaulted(vm, arg_rpc_ssl))
     {
       const std::string ssl = command_line::get_arg(vm, arg_rpc_ssl);
       if (!epee::net_utils::ssl_support_from_string(ssl_options.support, ssl))
       {
         MFATAL("Invalid RPC SSL support: " << ssl);
         return false;
-      };
+      }
     }
 
     auto rng = [](size_t len, uint8_t *ptr){ return crypto::rand(len, ptr); };

--- a/src/rpc/core_rpc_server.h
+++ b/src/rpc/core_rpc_server.h
@@ -60,7 +60,7 @@ namespace cryptonote
     static const command_line::arg_descriptor<std::string> arg_rpc_ssl;
     static const command_line::arg_descriptor<std::string> arg_rpc_ssl_private_key;
     static const command_line::arg_descriptor<std::string> arg_rpc_ssl_certificate;
-    static const command_line::arg_descriptor<std::vector<std::string>> arg_rpc_ssl_allowed_certificates;
+    static const command_line::arg_descriptor<std::string> arg_rpc_ssl_ca_certificates;
     static const command_line::arg_descriptor<std::vector<std::string>> arg_rpc_ssl_allowed_fingerprints;
     static const command_line::arg_descriptor<bool> arg_rpc_ssl_allow_any_cert;
     static const command_line::arg_descriptor<std::string> arg_bootstrap_daemon_address;

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -155,7 +155,7 @@ struct options {
   const command_line::arg_descriptor<std::string> daemon_ssl = {"daemon-ssl", tools::wallet2::tr("Enable SSL on daemon RPC connections: enabled|disabled|autodetect"), "autodetect"};
   const command_line::arg_descriptor<std::string> daemon_ssl_private_key = {"daemon-ssl-private-key", tools::wallet2::tr("Path to a PEM format private key"), ""};
   const command_line::arg_descriptor<std::string> daemon_ssl_certificate = {"daemon-ssl-certificate", tools::wallet2::tr("Path to a PEM format certificate"), ""};
-  const command_line::arg_descriptor<std::vector<std::string>> daemon_ssl_allowed_certificates = {"daemon-ssl-allowed-certificates", tools::wallet2::tr("List of paths to PEM format certificates of allowed RPC servers")};
+  const command_line::arg_descriptor<std::string> daemon_ssl_ca_certificates = {"daemon-ssl-ca-certificates", tools::wallet2::tr("Path to file containing concatenated PEM format certificate(s) to replace system CA(s).")};
   const command_line::arg_descriptor<std::vector<std::string>> daemon_ssl_allowed_fingerprints = {"daemon-ssl-allowed-fingerprints", tools::wallet2::tr("List of valid fingerprints of allowed RPC servers")};
   const command_line::arg_descriptor<bool> daemon_ssl_allow_any_cert = {"daemon-ssl-allow-any-cert", tools::wallet2::tr("Allow any SSL certificate from the daemon"), false};
   const command_line::arg_descriptor<bool> testnet = {"testnet", tools::wallet2::tr("For testnet. Daemon must also be launched with --testnet flag"), false};
@@ -226,13 +226,34 @@ std::unique_ptr<tools::wallet2> make_basic(const boost::program_options::variabl
   auto device_name = command_line::get_arg(vm, opts.hw_device);
   auto daemon_ssl_private_key = command_line::get_arg(vm, opts.daemon_ssl_private_key);
   auto daemon_ssl_certificate = command_line::get_arg(vm, opts.daemon_ssl_certificate);
-  auto daemon_ssl_allowed_certificates = command_line::get_arg(vm, opts.daemon_ssl_allowed_certificates);
+  auto daemon_ssl_ca_file = command_line::get_arg(vm, opts.daemon_ssl_ca_certificates);
   auto daemon_ssl_allowed_fingerprints = command_line::get_arg(vm, opts.daemon_ssl_allowed_fingerprints);
   auto daemon_ssl_allow_any_cert = command_line::get_arg(vm, opts.daemon_ssl_allow_any_cert);
   auto daemon_ssl = command_line::get_arg(vm, opts.daemon_ssl);
-  epee::net_utils::ssl_support_t ssl_support;
-  THROW_WALLET_EXCEPTION_IF(!epee::net_utils::ssl_support_from_string(ssl_support, daemon_ssl), tools::error::wallet_internal_error,
-      tools::wallet2::tr("Invalid argument for ") + std::string(opts.daemon_ssl.name));
+
+  // user specified CA file or fingeprints implies enabled SSL by default
+  epee::net_utils::ssl_options_t ssl_options = epee::net_utils::ssl_support_t::enabled;
+  if (command_line::get_arg(vm, opts.daemon_ssl_allow_any_cert))
+    ssl_options.verification = epee::net_utils::ssl_verification_t::none;
+  else if (!daemon_ssl_ca_file.empty() || !daemon_ssl_allowed_fingerprints.empty())
+  {
+    std::vector<std::vector<uint8_t>> ssl_allowed_fingerprints{ daemon_ssl_allowed_fingerprints.size() };
+    std::transform(daemon_ssl_allowed_fingerprints.begin(), daemon_ssl_allowed_fingerprints.end(), ssl_allowed_fingerprints.begin(), epee::from_hex::vector);
+
+    ssl_options = epee::net_utils::ssl_options_t{
+      std::move(ssl_allowed_fingerprints), std::move(daemon_ssl_ca_file)
+    };
+  }
+
+  if (ssl_options.verification != epee::net_utils::ssl_verification_t::user_certificates || !command_line::is_arg_defaulted(vm, opts.daemon_ssl))
+  {
+    THROW_WALLET_EXCEPTION_IF(!epee::net_utils::ssl_support_from_string(ssl_options.support, daemon_ssl), tools::error::wallet_internal_error,
+       tools::wallet2::tr("Invalid argument for ") + std::string(opts.daemon_ssl.name));
+  }
+
+  ssl_options.auth = epee::net_utils::ssl_authentication_t{
+    std::move(daemon_ssl_private_key), std::move(daemon_ssl_certificate)
+  };
 
   THROW_WALLET_EXCEPTION_IF(!daemon_address.empty() && !daemon_host.empty() && 0 != daemon_port,
       tools::error::wallet_internal_error, tools::wallet2::tr("can't specify daemon host or port more than once"));
@@ -283,22 +304,8 @@ std::unique_ptr<tools::wallet2> make_basic(const boost::program_options::variabl
     catch (const std::exception &e) { }
   }
 
-  std::list<std::string> ssl_allowed_certificates;
-  for (const std::string &path: daemon_ssl_allowed_certificates)
-  {
-      ssl_allowed_certificates.push_back({});
-      if (!epee::file_io_utils::load_file_to_string(path, ssl_allowed_certificates.back()))
-      {
-        MERROR("Failed to load certificate: " << path);
-        ssl_allowed_certificates.back() = std::string();
-      }
-  }
-
-  std::vector<std::vector<uint8_t>> ssl_allowed_fingerprints{ daemon_ssl_allowed_fingerprints.size() };
-  std::transform(daemon_ssl_allowed_fingerprints.begin(), daemon_ssl_allowed_fingerprints.end(), ssl_allowed_fingerprints.begin(), epee::from_hex::vector);
-
   std::unique_ptr<tools::wallet2> wallet(new tools::wallet2(nettype, kdf_rounds, unattended));
-  wallet->init(std::move(daemon_address), std::move(login), 0, *trusted_daemon, ssl_support, std::make_pair(daemon_ssl_private_key, daemon_ssl_certificate), ssl_allowed_certificates, ssl_allowed_fingerprints, daemon_ssl_allow_any_cert);
+  wallet->init(std::move(daemon_address), std::move(login), 0, *trusted_daemon, std::move(ssl_options));
 
   boost::filesystem::path ringdb_path = command_line::get_arg(vm, opts.shared_ringdb_dir);
   wallet->set_ring_database(ringdb_path.string());
@@ -888,7 +895,7 @@ void wallet2::init_options(boost::program_options::options_description& desc_par
   command_line::add_arg(desc_params, opts.daemon_ssl);
   command_line::add_arg(desc_params, opts.daemon_ssl_private_key);
   command_line::add_arg(desc_params, opts.daemon_ssl_certificate);
-  command_line::add_arg(desc_params, opts.daemon_ssl_allowed_certificates);
+  command_line::add_arg(desc_params, opts.daemon_ssl_ca_certificates);
   command_line::add_arg(desc_params, opts.daemon_ssl_allowed_fingerprints);
   command_line::add_arg(desc_params, opts.daemon_ssl_allow_any_cert);
   command_line::add_arg(desc_params, opts.testnet);
@@ -940,7 +947,7 @@ std::unique_ptr<wallet2> wallet2::make_dummy(const boost::program_options::varia
 }
 
 //----------------------------------------------------------------------------------------------------
-bool wallet2::init(std::string daemon_address, boost::optional<epee::net_utils::http::login> daemon_login, uint64_t upper_transaction_size_limit, bool trusted_daemon, epee::net_utils::ssl_support_t ssl_support, const std::pair<std::string, std::string> &private_key_and_certificate_path, const std::list<std::string> &allowed_certificates, const std::vector<std::vector<uint8_t>> &allowed_fingerprints, bool allow_any_cert)
+bool wallet2::init(std::string daemon_address, boost::optional<epee::net_utils::http::login> daemon_login, uint64_t upper_transaction_weight_limit, bool trusted_daemon, epee::net_utils::ssl_options_t ssl_options)
 {
   m_checkpoints.init_default_checkpoints(m_nettype);
   if(m_http_client.is_connected())
@@ -950,7 +957,7 @@ bool wallet2::init(std::string daemon_address, boost::optional<epee::net_utils::
   m_daemon_address = std::move(daemon_address);
   m_daemon_login = std::move(daemon_login);
   m_trusted_daemon = trusted_daemon;
-  return m_http_client.set_server(get_daemon_address(), get_daemon_login(), ssl_support, private_key_and_certificate_path, allowed_certificates, allowed_fingerprints, allow_any_cert);
+  return m_http_client.set_server(get_daemon_address(), get_daemon_login(), std::move(ssl_options));
 }
 //----------------------------------------------------------------------------------------------------
 bool wallet2::is_deterministic() const

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -947,7 +947,7 @@ std::unique_ptr<wallet2> wallet2::make_dummy(const boost::program_options::varia
 }
 
 //----------------------------------------------------------------------------------------------------
-bool wallet2::init(std::string daemon_address, boost::optional<epee::net_utils::http::login> daemon_login, uint64_t upper_transaction_weight_limit, bool trusted_daemon, epee::net_utils::ssl_options_t ssl_options)
+bool wallet2::init(std::string daemon_address, boost::optional<epee::net_utils::http::login> daemon_login, uint64_t upper_transaction_size_limit, bool trusted_daemon, epee::net_utils::ssl_options_t ssl_options)
 {
   m_checkpoints.init_default_checkpoints(m_nettype);
   if(m_http_client.is_connected())

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -652,10 +652,7 @@ namespace tools
     bool init(std::string daemon_address = "http://localhost:19994",
       boost::optional<epee::net_utils::http::login> daemon_login = boost::none, uint64_t upper_transaction_weight_limit = 0,
       bool trusted_daemon = true,
-      epee::net_utils::ssl_support_t ssl_support = epee::net_utils::ssl_support_t::e_ssl_support_autodetect,
-      const std::pair<std::string, std::string> &private_key_and_certificate_path = {},
-      const std::list<std::string> &allowed_certificates = {}, const std::vector<std::vector<uint8_t>> &allowed_fingerprints = {},
-      bool allow_any_cert = false);
+      epee::net_utils::ssl_options_t ssl_options = epee::net_utils::ssl_support_t::autodetect);
 
     void stop() { m_run.store(false, std::memory_order_relaxed); }
 

--- a/src/wallet/wallet_rpc_server.cpp
+++ b/src/wallet/wallet_rpc_server.cpp
@@ -67,7 +67,7 @@ namespace
   const command_line::arg_descriptor<std::string> arg_rpc_ssl = {"rpc-ssl", tools::wallet2::tr("Enable SSL on wallet RPC connections: enabled|disabled|autodetect <- Autodetect Set by Default"), "autodetect"};
   const command_line::arg_descriptor<std::string> arg_rpc_ssl_private_key = {"rpc-ssl-private-key", tools::wallet2::tr("Path to a PEM format private key"), ""};
   const command_line::arg_descriptor<std::string> arg_rpc_ssl_certificate = {"rpc-ssl-certificate", tools::wallet2::tr("Path to a PEM format certificate"), ""};
-  const command_line::arg_descriptor<std::vector<std::string>> arg_rpc_ssl_allowed_certificates = {"rpc-ssl-allowed-certificates", tools::wallet2::tr("List of paths to PEM format certificates of allowed RPC servers (all allowed if empty)")};
+  const command_line::arg_descriptor<std::string> arg_rpc_ssl_ca_certificates = {"rpc-ssl-ca-certificates", tools::wallet2::tr("Path to file containing concatenated PEM format certificate(s) to replace system CA(s).")};
   const command_line::arg_descriptor<std::vector<std::string>> arg_rpc_ssl_allowed_fingerprints = {"rpc-ssl-allowed-fingerprints", tools::wallet2::tr("List of certificate fingerprints to allow")};
 
   constexpr const char default_rpc_username[] = "arqma";
@@ -241,34 +241,40 @@ namespace tools
 
     auto rpc_ssl_private_key = command_line::get_arg(vm, arg_rpc_ssl_private_key);
     auto rpc_ssl_certificate = command_line::get_arg(vm, arg_rpc_ssl_certificate);
-    auto rpc_ssl_allowed_certificates = command_line::get_arg(vm, arg_rpc_ssl_allowed_certificates);
+    auto rpc_ssl_ca_file = command_line::get_arg(vm, arg_rpc_ssl_ca_certificates);
     auto rpc_ssl_allowed_fingerprints = command_line::get_arg(vm, arg_rpc_ssl_allowed_fingerprints);
     auto rpc_ssl = command_line::get_arg(vm, arg_rpc_ssl);
-    epee::net_utils::ssl_support_t rpc_ssl_support;
-    if (!epee::net_utils::ssl_support_from_string(rpc_ssl_support, rpc_ssl))
+    epee::net_utils::ssl_options_t rpc_ssl_options = epee::net_utils::ssl_support_t::enabled;
+
+    if (!rpc_ssl_ca_file.empty() || !rpc_ssl_allowed_fingerprints.empty())
     {
-      MERROR("Invalid argument for " << std::string(arg_rpc_ssl.name));
-      return false;
-    }
-    std::list<std::string> allowed_certificates;
-    for (const std::string &path: rpc_ssl_allowed_certificates)
-    {
-        allowed_certificates.push_back({});
-        if (!epee::file_io_utils::load_file_to_string(path, allowed_certificates.back()))
-        {
-          MERROR("Failed to load certificate: " << path);
-          allowed_certificates.back() = std::string();
-        }
+      std::vector<std::vector<uint8_t>> allowed_fingerprints{ rpc_ssl_allowed_fingerprints.size() };
+      std::transform(rpc_ssl_allowed_fingerprints.begin(), rpc_ssl_allowed_fingerprints.end(), allowed_fingerprints.begin(), epee::from_hex::vector);
+
+      rpc_ssl_options = epee::net_utils::ssl_options_t{
+        std::move(allowed_fingerprints), std::move(rpc_ssl_ca_file)
+      };
     }
 
-    std::vector<std::vector<uint8_t>> allowed_fingerprints{ rpc_ssl_allowed_fingerprints.size() };
-    std::transform(rpc_ssl_allowed_fingerprints.begin(), rpc_ssl_allowed_fingerprints.end(), allowed_fingerprints.begin(), epee::from_hex::vector);
+    // user specified CA file or fingeprints implies enabled SSL by default
+    if (rpc_ssl_options.verification != epee::net_utils::ssl_verification_t::user_certificates || !command_line::is_arg_defaulted(vm, arg_rpc_ssl))
+    {
+        if (!epee::net_utils::ssl_support_from_string(rpc_ssl_options.support, rpc_ssl))
+        {
+        MERROR("Invalid argument for " << std::string(arg_rpc_ssl.name));
+        return false;
+      }
+    }
+
+    rpc_ssl_options.auth = epee::net_utils::ssl_authentication_t{
+      std::move(rpc_ssl_private_key), std::move(rpc_ssl_certificate)
+    };
 
     m_net_server.set_threads_prefix("RPC");
     auto rng = [](size_t len, uint8_t *ptr) { return crypto::rand(len, ptr); };
     return epee::http_server_impl_base<wallet_rpc_server, connection_context>::init(
       rng, std::move(bind_port), std::move(rpc_config->bind_ip), std::move(rpc_config->access_control_origins), std::move(http_login),
-      rpc_ssl_support, std::make_pair(rpc_ssl_private_key, rpc_ssl_certificate), std::move(allowed_certificates), std::move(allowed_fingerprints)
+      std::move(rpc_ssl_options)
     );
   }
   //------------------------------------------------------------------------------------------------------------------------------
@@ -3769,7 +3775,7 @@ int main(int argc, char** argv) {
   command_line::add_arg(desc_params, arg_rpc_ssl);
   command_line::add_arg(desc_params, arg_rpc_ssl_private_key);
   command_line::add_arg(desc_params, arg_rpc_ssl_certificate);
-  command_line::add_arg(desc_params, arg_rpc_ssl_allowed_certificates);
+  command_line::add_arg(desc_params, arg_rpc_ssl_ca_certificates);
   command_line::add_arg(desc_params, arg_rpc_ssl_allowed_fingerprints);
 
   daemonizer::init_options(hidden_options, desc_params);


### PR DESCRIPTION
Specifying SSL certificates for peer verification does an exact match,
making it a not-so-obvious alias for the fingerprints option. This
changes the checks to OpenSSL which loads concatenated certificate(s)
from a single file and does a certificate-authority (chain of trust)
check instead. There is no drop in security - a compromised exact match
fingerprint has the same worse case failure. There is increased security
in allowing separate long-term CA key and short-term SSL server keys.

This also removes loading of the system-default CA files if a custom
CA file or certificate fingerprint is specified.

Currently a client must provide a certificate, even if the server is
configured to allow all certificates. This drops that requirement from
the client - unless the server is configured to use a CA file or
fingerprint(s) for verification - which is the standard behavior for SSL
servers.

The "system-wide" CA is not being used as a "fallback" to verify clients
before or after this patch.

Currently if a user specifies a ca file or fingerprint to verify peer,
the default behavior is SSL autodetect which allows for mitm downgrade
attacks. It should be investigated whether a manual override should be
allowed - the configuration is likely always invalid.

Using `verify_peer` on server side requests a certificate from the
client. If no certificate is provided, the server silently accepts the
connection and rejects if the client sends an unexpected certificate.
Adding `verify_fail_if_no_cert` has no affect on client and for server
requires that the peer sends a certificate or fails the handshake. This
is the desired behavior when the user specifies a fingerprint or CA file.

If SSL is "enabled" via command line without specifying a fingerprint or
certificate, the system CA list is checked for server verification and
_now_ fails the handshake if that check fails. This change was made to
remain consistent with standard SSL/TLS client behavior. This can still
be overridden by using the allow any certificate flag.

If the SSL behavior is autodetect, the system CA list is still checked
but a warning is logged if this fails. The stream is not rejected
because a re-connect will be attempted - its better to have an
unverified encrypted stream than an unverified + unencrypted stream.

If the verification mode is `system_ca`, clients will now do hostname
verification. Thus, only certificates from expected hostnames are
allowed when SSL is enabled. This can be overridden by forcible setting
the SSL mode to autodetect.

Clients will also send the hostname even when `system_ca` is not being
performed. This leaks possible metadata, but allows servers providing
multiple hostnames to respond with the correct certificate.

The former has the same behavior with single self signed certificates
while allowing the server to have separate short-term authentication
keys with long-term authorization keys.