### PR TITLE
discontinue use of alloca

### DIFF
--- a/src/common/spawn.cpp
+++ b/src/common/spawn.cpp
@@ -89,7 +89,7 @@ int spawn(const char *filename, const std::vector<std::string>& args, bool wait)
   MINFO("Child exited with " << exitCode);
   return static_cast<int>(exitCode);
 #else
-  char **argv = (char**)alloca(sizeof(char*) * (args.size() + 1));
+  std::vector<char*> argv(args.size() + 1);
   for (size_t n = 0; n < args.size(); ++n)
     argv[n] = (char*)args[n].c_str();
   argv[args.size()] = NULL;
@@ -107,7 +107,7 @@ int spawn(const char *filename, const std::vector<std::string>& args, bool wait)
     tools::closefrom(3);
     close(0);
     char *envp[] = {NULL};
-    execve(filename, argv, envp);
+    execve(filename, argv.data(), envp);
     MERROR("Failed to execve: " << strerror(errno));
     return -1;
   }

--- a/src/crypto/tree-hash.c
+++ b/src/crypto/tree-hash.c
@@ -1,21 +1,21 @@
 // Copyright (c) 2014-2018, The Monero Project
-// 
+//
 // All rights reserved.
-// 
+//
 // Redistribution and use in source and binary forms, with or without modification, are
 // permitted provided that the following conditions are met:
-// 
+//
 // 1. Redistributions of source code must retain the above copyright notice, this list of
 //    conditions and the following disclaimer.
-// 
+//
 // 2. Redistributions in binary form must reproduce the above copyright notice, this list
 //    of conditions and the following disclaimer in the documentation and/or other
 //    materials provided with the distribution.
-// 
+//
 // 3. Neither the name of the copyright holder nor the names of its contributors may be
 //    used to endorse or promote products derived from this software without specific
 //    prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
 // EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
 // MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
@@ -25,7 +25,7 @@
 // INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
 // STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
 // THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
+//
 // Parts of this file are originally copyright (c) 2012-2013 The Cryptonote developers
 
 #include <assert.h>
@@ -34,15 +34,7 @@
 
 #include "hash-ops.h"
 
-#ifdef _MSC_VER
-#include <malloc.h>
-#elif !defined(__FreeBSD__) && !defined(__OpenBSD__) && !defined(__DragonFly__)
- #include <alloca.h>
-#else
- #include <stdlib.h>
-#endif
-
-/*** 
+/***
 * Round to power of two, for count>=3 and for count being not too large (as reasonable for tree hash calculations)
 */
 size_t tree_hash_cnt(size_t count) {
@@ -90,9 +82,8 @@ void tree_hash(const char (*hashes)[HASH_SIZE], size_t count, char *root_hash) {
 
     size_t cnt = tree_hash_cnt( count );
 
-    char (*ints)[HASH_SIZE];
-    size_t ints_size = cnt * HASH_SIZE;
-    ints = alloca(ints_size); 	memset( ints , 0 , ints_size);  // allocate, and zero out as extra protection for using uninitialized mem
+    char ints[cnt][HASH_SIZE];
+    memset(ints, 0 , sizeof(ints));
 
     memcpy(ints, hashes, (2 * cnt - count) * HASH_SIZE);
 


### PR DESCRIPTION
man 3 alloca says:

       Normally,  gcc(1)  translates  calls  to  alloca()  with  inlined code.  This is not done when either the -ansi, -std=c89, -std=c99, or the
       -std=c11 option is given and the header <alloca.h> is not included.  Otherwise, (without an -ansi or -std=c* option) the glibc  version  of
       <stdlib.h> includes <alloca.h> and that contains the lines:

           #ifdef  __GNUC__
           #define alloca(size)   __builtin_alloca (size)
           #endif

It looks like alloca is a bad idea in modern C/C++, so we use
VLAs for C and std::vector for C++.