### PR TITLE
backtrace compatibility build fix < GLIBC_2.25 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,10 @@ depends:
 	cd contrib/depends && $(MAKE) HOST=$(target) && cd ../.. && mkdir -p build/$(target)/release
 	cd build/$(target)/release && cmake -DCMAKE_TOOLCHAIN_FILE=$(CURDIR)/contrib/depends/$(target)/share/toolchain.cmake ../../.. && $(MAKE)
 
+depends-compat:
+	cd contrib/depends && $(MAKE) HOST=$(target) && cd ../.. && mkdir -p build/$(target)/release
+	cd build/$(target)/release && cmake -DBACKCOMPAT=ON -DCMAKE_TOOLCHAIN_FILE=$(CURDIR)/contrib/depends/$(target)/share/toolchain.cmake ../../.. && $(MAKE)
+
 cmake-debug:
 	mkdir -p $(builddir)/debug
 	cd $(builddir)/debug && cmake -D CMAKE_BUILD_TYPE=Debug $(topdir)

--- a/README.md
+++ b/README.md
@@ -466,7 +466,7 @@ You can also cross-compile Arqma static binaries on Linux for Windows and macOS 
 * ```make depends target=arm-linux-gnueabihf``` for armv7 binaries. Requires: g++-arm-linux-gnueabihf
 * ```make depends target=aarch64-linux-gnu``` for armv8 binaries. Requires: g++-aarch64-linux-gnu
 
-*** For `x86_64-apple-darwin11` you need to download SDK first ***    
+*** For `x86_64-apple-darwin14` you need to download SDK first ***    
 
 * ```git clone -b arqma https://github.com/malbit/MacOSX-SDKs.git contrib/depends/SDKs ```    
 
@@ -476,7 +476,10 @@ The required packages are the names for each toolchain on apt. Depending on your
 
 Using `depends` might also be easier to compile Arqma on Windows than using MSYS. Activate Windows Subsystem for Linux (WSL) with a distribution (for example Ubuntu), install the apt build-essentials and follow the `depends` steps as stated above.
 
-The produced binaries still link libc dynamically. If the binary is compiled on a current distribution, it might not run on an older distribution with an older installation of libc. Passing `-DBACKCOMPAT=ON` to cmake will make sure that the binary will run on systems having at least libc version 2.17.
+### Compability with older Linux Versions < GLIBC_2.25
+
+* ```make depends-compat target=x86_64-linux-gnu``` for 64-bit linux binaries.
+
 
 ## Running arqmad
 

--- a/cmake/FindBacktrace.cmake
+++ b/cmake/FindBacktrace.cmake
@@ -1,0 +1,98 @@
+# Distributed under the OSI-approved BSD 3-Clause License.  See accompanying
+# file Copyright.txt or https://cmake.org/licensing for details.
+
+#.rst:
+# FindBacktrace
+# -------------
+#
+# Find provider for backtrace(3).
+#
+# Checks if OS supports backtrace(3) via either libc or custom library.
+# This module defines the following variables:
+#
+# ``Backtrace_HEADER``
+#   The header file needed for backtrace(3). Cached.
+#   Could be forcibly set by user.
+# ``Backtrace_INCLUDE_DIRS``
+#   The include directories needed to use backtrace(3) header.
+# ``Backtrace_LIBRARIES``
+#   The libraries (linker flags) needed to use backtrace(3), if any.
+# ``Backtrace_FOUND``
+#   Is set if and only if backtrace(3) support detected.
+#
+# The following cache variables are also available to set or use:
+#
+# ``Backtrace_LIBRARY``
+#   The external library providing backtrace, if any.
+# ``Backtrace_INCLUDE_DIR``
+#   The directory holding the backtrace(3) header.
+#
+# Typical usage is to generate of header file using configure_file() with the
+# contents like the following::
+#
+#  #cmakedefine01 Backtrace_FOUND
+#  #if Backtrace_FOUND
+#  # include <${Backtrace_HEADER}>
+#  #endif
+#
+# And then reference that generated header file in actual source.
+
+include(CMakePushCheckState)
+include(CheckSymbolExists)
+include(FindPackageHandleStandardArgs)
+
+# List of variables to be provided to find_package_handle_standard_args()
+set(_Backtrace_STD_ARGS Backtrace_INCLUDE_DIR)
+
+if(Backtrace_HEADER)
+  set(_Backtrace_HEADER_TRY "${Backtrace_HEADER}")
+else(Backtrace_HEADER)
+  set(_Backtrace_HEADER_TRY "execinfo.h")
+endif(Backtrace_HEADER)
+
+find_path(Backtrace_INCLUDE_DIR "${_Backtrace_HEADER_TRY}")
+set(Backtrace_INCLUDE_DIRS ${Backtrace_INCLUDE_DIR})
+
+if (NOT DEFINED Backtrace_LIBRARY)
+  # First, check if we already have backtrace(), e.g., in libc
+  cmake_push_check_state(RESET)
+  set(CMAKE_REQUIRED_INCLUDES ${Backtrace_INCLUDE_DIRS})
+  set(CMAKE_REQUIRED_QUIET ${Backtrace_FIND_QUIETLY})
+  check_symbol_exists("backtrace" "${_Backtrace_HEADER_TRY}" _Backtrace_SYM_FOUND)
+  cmake_pop_check_state()
+endif()
+
+if(_Backtrace_SYM_FOUND)
+  # Avoid repeating the message() call below each time CMake is run.
+  if(NOT Backtrace_FIND_QUIETLY AND NOT DEFINED Backtrace_LIBRARY)
+    message(STATUS "backtrace facility detected in default set of libraries")
+  endif()
+  set(Backtrace_LIBRARY "" CACHE FILEPATH "Library providing backtrace(3), empty for default set of libraries")
+else()
+  # Check for external library, for non-glibc systems
+  if(Backtrace_INCLUDE_DIR)
+    # OpenBSD has libbacktrace renamed to libexecinfo
+    find_library(Backtrace_LIBRARY "execinfo")
+  elseif()     # respect user wishes
+    set(_Backtrace_HEADER_TRY "backtrace.h")
+    find_path(Backtrace_INCLUDE_DIR ${_Backtrace_HEADER_TRY})
+    find_library(Backtrace_LIBRARY "backtrace")
+  endif()
+
+  # Prepend list with library path as it's more common practice
+  set(_Backtrace_STD_ARGS Backtrace_LIBRARY ${_Backtrace_STD_ARGS})
+endif()
+
+message(STATUS "Backtrace_LIBRARY: ${Backtrace_LIBRARY}")
+if(Backtrace_LIBRARY STREQUAL "NOTFOUND")
+  set(Backtrace_LIBRARY "")
+endif()
+if(Backtrace_LIBRARY STREQUAL "Backtrace_LIBRARY-NOTFOUND")
+  set(Backtrace_LIBRARY "")
+endif()
+
+set(Backtrace_LIBRARIES ${Backtrace_LIBRARY})
+set(Backtrace_HEADER "${_Backtrace_HEADER_TRY}" CACHE STRING "Header providing backtrace(3) facility")
+
+find_package_handle_standard_args(Backtrace FOUND_VAR Backtrace_FOUND REQUIRED_VARS ${_Backtrace_STD_ARGS})
+mark_as_advanced(Backtrace_HEADER Backtrace_INCLUDE_DIR Backtrace_LIBRARY)

--- a/src/common/compat/glibc_compat.cpp
+++ b/src/common/compat/glibc_compat.cpp
@@ -1,0 +1,97 @@
+#include <cstddef>
+#include <cstdint>
+#include <strings.h>
+#include <string.h>
+#include <glob.h>
+#include <unistd.h>
+#include <fnmatch.h>
+
+#if defined(HAVE_SYS_SELECT_H)
+#include <sys/select.h>
+#endif
+
+// Prior to GLIBC_2.14, memcpy was aliased to memmove.
+extern "C" void* memmove(void* a, const void* b, size_t c);
+//extern "C" void* memset(void* a, int b, long unsigned int c);
+extern "C" void* memcpy(void* a, const void* b, size_t c)
+{
+    return memmove(a, b, c);
+}
+
+extern "C" void __chk_fail(void) __attribute__((__noreturn__));
+
+#if defined(__i386__) || defined(__arm__)
+
+extern "C" int64_t __udivmoddi4(uint64_t u, uint64_t v, uint64_t* rp);
+
+extern "C" int64_t __wrap___divmoddi4(int64_t u, int64_t v, int64_t* rp)
+{
+    int32_t c1 = 0, c2 = 0;
+    int64_t uu = u, vv = v;
+    int64_t w;
+    int64_t r;
+
+    if (uu < 0) {
+        c1 = ~c1, c2 = ~c2, uu = -uu;
+    }
+    if (vv < 0) {
+        c1 = ~c1, vv = -vv;
+    }
+
+    w = __udivmoddi4(uu, vv, (uint64_t*)&r);
+    if (c1)
+        w = -w;
+    if (c2)
+        r = -r;
+
+    *rp = r;
+    return w;
+}
+#endif
+
+/* glibc-internal users use __explicit_bzero_chk, and explicit_bzero
+   redirects to that.  */
+#undef explicit_bzero
+/* Set LEN bytes of S to 0.  The compiler will not delete a call to
+   this function, even if S is dead after the call.  */
+void
+explicit_bzero (void *s, size_t len)
+{
+  memset (s, '\0', len);
+  /* Compiler barrier.  */
+  asm volatile ("" ::: "memory");
+}
+
+// Redefine explicit_bzero_chk
+void
+__explicit_bzero_chk (void *dst, size_t len, size_t dstlen)
+{
+  /* Inline __memset_chk to avoid a PLT reference to __memset_chk.  */
+  if (__glibc_unlikely (dstlen < len))
+    __chk_fail ();
+  memset (dst, '\0', len);
+  /* Compiler barrier.  */
+  asm volatile ("" ::: "memory");
+}
+/* libc-internal references use the hidden
+   __explicit_bzero_chk_internal symbol.  This is necessary if
+   __explicit_bzero_chk is implemented as an IFUNC because some
+   targets do not support hidden references to IFUNC symbols.  */
+#define strong_alias (__explicit_bzero_chk, __explicit_bzero_chk_internal)
+
+#undef glob
+extern "C" int glob_old(const char * pattern, int flags, int (*errfunc) (const char *epath, int eerrno), glob_t *pglob);
+#ifdef __i386__
+__asm__(".symver glob_old,glob@GLIBC_2.0");
+#elif defined(__amd64__)
+__asm__(".symver glob_old,glob@GLIBC_2.2.5");
+#elif defined(__arm__)
+__asm(".symver glob_old,glob@GLIBC_2.4");
+#elif defined(__aarch64__)
+__asm__(".symver glob_old,glob@GLIBC_2.17");
+#endif
+
+extern "C" int __wrap_glob(const char * pattern, int flags, int (*errfunc) (const char *epath, int eerrno), glob_t *pglob)
+{
+    return glob_old(pattern, flags, errfunc, pglob);
+}


### PR DESCRIPTION
Makefile updated to invoke: make depends-compat target=x86_64-linux-gnu <- to build static binaries compatible with older Linux versions