### PR TITLE
blockchain: add --reorg-notify

### DIFF
--- a/src/common/notify.cpp
+++ b/src/common/notify.cpp
@@ -51,11 +51,26 @@ Notify::Notify(const char *spec)
   CHECK_AND_ASSERT_THROW_MES(epee::file_io_utils::is_file_exist(filename), "File not found: " << filename);
 }
 
-int Notify::notify(const char *parameter)
+static void replace(std::vector<std::string> &v, const char *tag, const char *s)
+{
+  for (std::string &str: v)
+    boost::replace_all(str, tag, s);
+}
+
+int Notify::notify(const char *tag, const char *s, ...)
 {
   std::vector<std::string> margs = args;
-  for (std::string &s: margs)
-    boost::replace_all(s, "%s", parameter);
+
+  replace(margs, tag, s);
+
+  va_list ap;
+  va_start(ap, s);
+  while ((tag = va_arg(ap, const char*)))
+  {
+    s = va_arg(ap, const char*);
+    replace(margs, tag, s);
+  }
+  va_end(ap);
 
   return tools::spawn(filename.c_str(), margs, false);
 }

--- a/src/common/notify.h
+++ b/src/common/notify.h
@@ -40,7 +40,7 @@ class Notify
 public:
   Notify(const char *spec);
 
-  int notify(const char *parameter);
+  int notify(const char *tag, const char *s, ...);
 
 private:
   std::string filename;

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -403,7 +403,7 @@ bool Blockchain::init(BlockchainDB* db, const network_type nettype, bool offline
   }
 
   db_rtxn_guard rtxn_guard(m_db);
-  
+
   // check how far behind we are
   uint64_t top_block_timestamp = m_db->get_top_block_timestamp();
   uint64_t timestamp_diff = time(NULL) - top_block_timestamp;
@@ -424,7 +424,7 @@ bool Blockchain::init(BlockchainDB* db, const network_type nettype, bool offline
 #endif
 
   MINFO("Blockchain initialized. last block: " << m_db->height() - 1 << ", " << epee::misc_utils::get_time_interval_string(timestamp_diff) << " time ago, current difficulty: " << get_difficulty_for_next_block());
-  
+
   rtxn_guard.stop();
 
   uint64_t num_popped_blocks = 0;
@@ -1126,6 +1126,7 @@ bool Blockchain::switch_to_alternative_blockchain(std::list<blocks_ext_by_hash::
   }
 
   // if we're to keep the disconnected blocks, add them as alternates
+  const size_t discarded_blocks = disconnected_chain.size();
   if(!discard_disconnected_chain)
   {
     //pushing old chain as alternative chain
@@ -1149,6 +1150,11 @@ bool Blockchain::switch_to_alternative_blockchain(std::list<blocks_ext_by_hash::
   }
 
   m_hardfork->reorganize_from_chain_height(split_height);
+
+  std::shared_ptr<tools::Notify> reorg_notify = m_reorg_notify;
+  if (reorg_notify)
+    reorg_notify->notify("%s", std::to_string(split_height).c_str(), "%h", std::to_string(m_db->height()).c_str(),
+        "%n", std::to_string(m_db->height() - split_height).c_str(), "%d", std::to_string(discarded_blocks).c_str(), NULL);
 
   MGINFO_GREEN("REORGANIZE SUCCESS! on height: " << split_height << ", new blockchain size: " << m_db->height());
   return true;
@@ -2016,7 +2022,7 @@ bool Blockchain::get_output_distribution(uint64_t amount, uint64_t from_height, 
 {
   // rct outputs don't exist before v4
   // Arqma did start from v7 at blockheight 1 so our start is always 0
-  
+
   start_height = 0;
   base = 0;
 
@@ -3893,7 +3899,7 @@ leave:
 
   std::shared_ptr<tools::Notify> block_notify = m_block_notify;
   if (block_notify)
-    block_notify->notify(epee::string_tools::pod_to_hex(id).c_str());
+    block_notify->notify(epee::string_tools::pod_to_hex(id).c_str(), NULL);
 
   return true;
 }

--- a/src/cryptonote_core/blockchain.h
+++ b/src/cryptonote_core/blockchain.h
@@ -743,6 +743,13 @@ namespace cryptonote
     void set_block_notify(const std::shared_ptr<tools::Notify> &notify) { m_block_notify = notify; }
 
     /**
+     * @brief sets a reorg notify object to call for every reorg
+     *
+     * @param notify the notify object to call at every reorg
+     */
+    void set_reorg_notify(const std::shared_ptr<tools::Notify> &notify) { m_reorg_notify = notify; }
+
+    /**
      * @brief Put DB in safe sync mode
      */
     void safesyncmode(const bool onoff);
@@ -1082,6 +1089,8 @@ namespace cryptonote
     bool m_btc_valid;
 
     std::shared_ptr<tools::Notify> m_block_notify;
+    std::shared_ptr<tools::Notify> m_reorg_notify;
+
 
     /**
      * @brief collects the keys for all outputs being "spent" as an input

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -190,6 +190,15 @@ namespace cryptonote
   , false
   };
 
+  static const command_line::arg_descriptor<std::string> arg_reorg_notify = {
+    "reorg-notify"
+  , "Run a program for each reorg, '%s' will be replaced by the split height, "
+    "'%h' will be replaced by the new blockchain height, '%n' will be "
+    "replaced by the number of new blocks in the new chain, and '%d' will be "
+    "replaced by the number of blocks discarded from the old chain"
+  , ""
+  };
+
   //-----------------------------------------------------------------------------------------------
   core::core(i_cryptonote_protocol* pprotocol):
               m_mempool(m_blockchain_storage),
@@ -303,6 +312,7 @@ namespace cryptonote
     command_line::add_arg(desc, arg_pad_transactions);
     command_line::add_arg(desc, arg_block_notify);
     command_line::add_arg(desc, arg_prune_blockchain);
+    command_line::add_arg(desc, arg_reorg_notify);
 
     miner::init_options(desc);
     BlockchainDB::init_options(desc);
@@ -584,6 +594,16 @@ namespace cryptonote
     catch (const std::exception &e)
     {
       MERROR("Failed to parse block notify spec");
+    }
+
+    try
+    {
+      if (!command_line::is_arg_defaulted(vm, arg_reorg_notify))
+      m_blockchain_storage.set_reorg_notify(std::shared_ptr<tools::Notify>(new tools::Notify(command_line::get_arg(vm, arg_reorg_notify).c_str())));
+    }
+    catch (const std::exception &e)
+    {
+      MERROR("Failed to parse reorg notify spec");
     }
 
     const std::pair<uint8_t, uint64_t> regtest_hard_forks[3] = {std::make_pair(1, 0), std::make_pair(Blockchain::get_hard_fork_heights(MAINNET).back().version, 1), std::make_pair(0, 0)};


### PR DESCRIPTION
This will trigger if a reorg is seen. This may be used to do things
like stop automated withdrawals on large reorgs.

%s is replaced by the height at the split point
%h is replaced by the height of the new chain
%n is replaced by the number of new blocks after the reorg
%d is replaced by the number of discarded blocks