### PR TITLE
daemon_rpc_server: added COMMAND_RPC_GET_BLOCKS_RANGE.

### DIFF
--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -83,7 +83,7 @@ namespace
       uint64_t time;
       uint64_t credits;
     };
-    
+
     RPCTracker(const char *rpc, tools::LoggingPerformanceTimer &timer): rpc(rpc), timer(timer) {
     }
     ~RPCTracker() {
@@ -335,13 +335,13 @@ namespace cryptonote
     res.rpc_connections_count = restricted ? 0 : get_connections_count();
     res.white_peerlist_size = restricted ? 0 : m_p2p.get_public_white_peers_count();
     res.grey_peerlist_size = restricted ? 0 : m_p2p.get_public_gray_peers_count();
-    
+
     cryptonote::network_type net_type = nettype();
     res.mainnet = net_type == MAINNET;
     res.testnet = net_type == TESTNET;
     res.stagenet = net_type == STAGENET;
     res.nettype = net_type == MAINNET ? "mainnet" : net_type == TESTNET ? "testnet" : net_type == STAGENET ? "stagenet" : "fakechain";
-    
+
     res.cumulative_difficulty = m_core.get_blockchain_storage().get_db().get_block_cumulative_difficulty(res.height - 1);
     res.block_size_limit = res.block_weight_limit = m_core.get_blockchain_storage().get_current_cumulative_block_weight_limit();
     res.block_size_median = res.block_weight_median = m_core.get_blockchain_storage().get_current_cumulative_block_weight_median();
@@ -1169,7 +1169,7 @@ namespace cryptonote
   bool core_rpc_server::on_get_public_nodes(const COMMAND_RPC_GET_PUBLIC_NODES::request& req, COMMAND_RPC_GET_PUBLIC_NODES::response& res, const connection_context *ctx)
   {
     RPC_TRACKER(get_public_nodes);
-    
+
     COMMAND_RPC_GET_PEER_LIST::response peer_list_res;
     const bool success = on_get_peer_list(COMMAND_RPC_GET_PEER_LIST::request(), peer_list_res, ctx);
     res.status = peer_list_res.status;
@@ -1181,7 +1181,7 @@ namespace cryptonote
     {
       return true;
     }
-    
+
     const auto collect = [](const std::vector<peer> &peer_list, std::vector<public_node> &public_nodes)
     {
       for (const auto &entry : peer_list)
@@ -1192,7 +1192,7 @@ namespace cryptonote
         }
       }
     };
-    
+
     if (req.white)
     {
       collect(peer_list_res.white_list, res.white);
@@ -1201,7 +1201,7 @@ namespace cryptonote
     {
       collect(peer_list_res.gray_list, res.gray);
     }
-    
+
     return true;
   }
   //------------------------------------------------------------------------------------------------------------------------------
@@ -1854,6 +1854,92 @@ namespace cryptonote
         error_resp.message = "Internal error: can't produce valid response.";
         return false;
       }
+    }
+    res.status = CORE_RPC_STATUS_OK;
+    return true;
+  }
+  //------------------------------------------------------------------------------------------------------------------------------
+  using std::cout;
+  using std::endl;
+  bool core_rpc_server::on_get_blocks_range(const COMMAND_RPC_GET_BLOCKS_RANGE::request& req, COMMAND_RPC_GET_BLOCKS_RANGE::response& res, epee::json_rpc::error& error_resp, const connection_context *ctx)
+  {
+    RPC_TRACKER(get_blocks_range);
+    bool r;
+    if (use_bootstrap_daemon_if_necessary<COMMAND_RPC_GET_BLOCKS_RANGE>(invoke_http_mode::JON_RPC, "getblocksrange", req, res, r))
+      return r;
+
+    const uint64_t bc_height = m_core.get_current_blockchain_height();
+    if (req.start_height >= bc_height || req.end_height >= bc_height || req.start_height > req.end_height)
+    {
+      error_resp.code = CORE_RPC_ERROR_CODE_TOO_BIG_HEIGHT;
+      error_resp.message = "Invalid start/end heights.";
+      return false;
+    }
+    CHECK_PAYMENT_MIN1(req, res, (req.end_height - req.start_height + 1) * COST_PER_BLOCK, false);
+    for (uint64_t h = req.start_height; h <= req.end_height; ++h)
+    {
+      crypto::hash block_hash = m_core.get_block_id_by_height(h);
+      block blk;
+      bool have_block = m_core.get_block_by_hash(block_hash, blk);
+      if (!have_block)
+      {
+        error_resp.code = CORE_RPC_ERROR_CODE_INTERNAL_ERROR;
+        error_resp.message = "Internal error: can't get block by height. Height = " + boost::lexical_cast<std::string>(h) + ". Hash = " + epee::string_tools::pod_to_hex(block_hash) + '.';
+        return false;
+      }
+      if (blk.miner_tx.vin.size() != 1 || blk.miner_tx.vin.front().type() != typeid(txin_gen))
+      {
+        error_resp.code = CORE_RPC_ERROR_CODE_INTERNAL_ERROR;
+        error_resp.message = "Internal error: coinbase transaction in the block has the wrong type";
+        return false;
+      }
+      uint64_t block_height = boost::get<txin_gen>(blk.miner_tx.vin.front()).height;
+      if (block_height != h)
+      {
+        error_resp.code = CORE_RPC_ERROR_CODE_INTERNAL_ERROR;
+        error_resp.message = "Internal error: coinbase transaction in the block has the wrong height";
+        return false;
+      }
+      block_header_response block_header = block_header_response();
+      bool response_filled = fill_block_header_response(blk, false, block_height, block_hash, block_header, true);
+      if (!response_filled)
+      {
+        error_resp.code = CORE_RPC_ERROR_CODE_INTERNAL_ERROR;
+        error_resp.message = "Internal error: can't produce valid response.";
+        return false;
+      }
+      // insert miner_tx at the beginning of the vector
+      blk.tx_hashes.push_back(cryptonote::get_transaction_hash(blk.miner_tx));
+      std::rotate(blk.tx_hashes.rbegin(), blk.tx_hashes.rbegin() + 1, blk.tx_hashes.rend());
+
+      std::vector<crypto::hash> missed_txs;
+      std::vector<std::tuple<crypto::hash, cryptonote::blobdata, crypto::hash, cryptonote::blobdata>> txs;
+      std::vector<COMMAND_RPC_GET_BLOCKS_RANGE::blocks_transaction_entry> txs_entries;
+
+      bool r = m_core.get_split_transactions_blobs(blk.tx_hashes, txs, missed_txs);
+
+      std::vector<crypto::hash>::const_iterator vhi = blk.tx_hashes.begin();
+      for(auto& tx: txs)
+      {
+        txs_entries.push_back(COMMAND_RPC_GET_BLOCKS_RANGE::blocks_transaction_entry());
+        COMMAND_RPC_GET_BLOCKS_RANGE::blocks_transaction_entry &e = txs_entries.back();
+
+        e.tx_hash = epee::string_tools::pod_to_hex(*vhi++);
+
+        cryptonote::blobdata tx_data;
+        cryptonote::transaction t;
+        tx_data = std::get<1>(tx) + std::get<3>(tx);
+        if (cryptonote::parse_and_validate_tx_from_blob(tx_data, t))
+          {
+            e.as_json = obj_to_json_str(t);
+          }
+          else
+          {
+            res.status = "Failed to parse and validate tx from blob";
+            return true;
+          }
+      }
+      res.blocks.emplace_back(block_header, txs_entries);
     }
     res.status = CORE_RPC_STATUS_OK;
     return true;
@@ -2570,7 +2656,7 @@ namespace cryptonote
     bool r;
     if (use_bootstrap_daemon_if_necessary<COMMAND_RPC_GET_OUTPUT_DISTRIBUTION>(invoke_http_mode::BIN, "/get_output_distribution.bin", req, res, r))
       return r;
-      
+
     size_t n_0 = 0, n_non0 = 0;
     for (uint64_t amount: req.amounts)
       if (amount) ++n_non0; else ++n_0;

--- a/src/rpc/core_rpc_server.h
+++ b/src/rpc/core_rpc_server.h
@@ -151,6 +151,8 @@ namespace cryptonote
         MAP_JON_RPC_WE("getblockheaderbyheight", on_get_block_header_by_height, COMMAND_RPC_GET_BLOCK_HEADER_BY_HEIGHT)
         MAP_JON_RPC_WE("get_block_headers_range", on_get_block_headers_range,   COMMAND_RPC_GET_BLOCK_HEADERS_RANGE)
         MAP_JON_RPC_WE("getblockheadersrange",   on_get_block_headers_range,    COMMAND_RPC_GET_BLOCK_HEADERS_RANGE)
+        MAP_JON_RPC_WE("get_blocks_range", on_get_blocks_range,   COMMAND_RPC_GET_BLOCKS_RANGE)
+        MAP_JON_RPC_WE("getblocksrange",   on_get_blocks_range,    COMMAND_RPC_GET_BLOCKS_RANGE)
         MAP_JON_RPC_WE("get_block",              on_get_block,                  COMMAND_RPC_GET_BLOCK)
         MAP_JON_RPC_WE("getblock",                on_get_block,                 COMMAND_RPC_GET_BLOCK)
         MAP_JON_RPC_WE_IF("get_connections",     on_get_connections,            COMMAND_RPC_GET_CONNECTIONS, !m_restricted)
@@ -225,6 +227,7 @@ namespace cryptonote
     bool on_get_block_header_by_hash(const COMMAND_RPC_GET_BLOCK_HEADER_BY_HASH::request& req, COMMAND_RPC_GET_BLOCK_HEADER_BY_HASH::response& res, epee::json_rpc::error& error_resp, const connection_context *ctx = NULL);
     bool on_get_block_header_by_height(const COMMAND_RPC_GET_BLOCK_HEADER_BY_HEIGHT::request& req, COMMAND_RPC_GET_BLOCK_HEADER_BY_HEIGHT::response& res, epee::json_rpc::error& error_resp, const connection_context *ctx = NULL);
     bool on_get_block_headers_range(const COMMAND_RPC_GET_BLOCK_HEADERS_RANGE::request& req, COMMAND_RPC_GET_BLOCK_HEADERS_RANGE::response& res, epee::json_rpc::error& error_resp, const connection_context *ctx = NULL);
+    bool on_get_blocks_range(const COMMAND_RPC_GET_BLOCKS_RANGE::request& req, COMMAND_RPC_GET_BLOCKS_RANGE::response& res, epee::json_rpc::error& error_resp, const connection_context *ctx = NULL);
     bool on_get_block(const COMMAND_RPC_GET_BLOCK::request& req, COMMAND_RPC_GET_BLOCK::response& res, epee::json_rpc::error& error_resp, const connection_context *ctx = NULL);
     bool on_get_connections(const COMMAND_RPC_GET_CONNECTIONS::request& req, COMMAND_RPC_GET_CONNECTIONS::response& res, epee::json_rpc::error& error_resp, const connection_context *ctx = NULL);
     bool on_get_info_json(const COMMAND_RPC_GET_INFO::request& req, COMMAND_RPC_GET_INFO::response& res, epee::json_rpc::error& error_resp, const connection_context *ctx = NULL);

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -126,7 +126,7 @@ namespace cryptonote
   {
     uint64_t credits;
     std::string top_hash;
-    
+
     rpc_access_response_base(): credits(0) {}
 
     BEGIN_KV_SERIALIZE_MAP()
@@ -1201,13 +1201,13 @@ namespace cryptonote
     uint64_t last_seen;
     uint16_t rpc_port;
     uint32_t rpc_credits_per_hash;
-    
+
     public_node(): last_seen(0), rpc_port(0), rpc_credits_per_hash(0) {}
-    
+
     public_node(const peer &peer)
       : host(peer.host), last_seen(peer.last_seen), rpc_port(peer.rpc_port), rpc_credits_per_hash(peer.rpc_credits_per_hash)
     {}
-      
+
     BEGIN_KV_SERIALIZE_MAP()
       KV_SERIALIZE(host)
       KV_SERIALIZE(last_seen)
@@ -1222,7 +1222,7 @@ namespace cryptonote
     {
       bool gray;
       bool white;
-      
+
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE_PARENT(rpc_request_base)
         KV_SERIALIZE_OPT(gray, false)
@@ -1230,12 +1230,12 @@ namespace cryptonote
       END_KV_SERIALIZE_MAP()
     };
     typedef epee::misc_utils::struct_init<request_t> request;
-    
+
     struct response_t: public rpc_response_base
     {
       std::vector<public_node> gray;
       std::vector<public_node> white;
-      
+
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE_PARENT(rpc_response_base)
         KV_SERIALIZE(gray)
@@ -1551,6 +1551,66 @@ namespace cryptonote
     typedef epee::misc_utils::struct_init<response_t> response;
   };
 
+struct COMMAND_RPC_GET_BLOCKS_RANGE
+  {
+    struct blocks_transaction_entry
+    {
+      std::string tx_hash;
+      std::string as_json;
+
+      blocks_transaction_entry() = default;
+
+      blocks_transaction_entry(const std::string &tx_hash, const std::string &as_json)
+        : tx_hash(tx_hash), as_json(as_json)
+      {}
+
+      BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE(tx_hash)
+        KV_SERIALIZE(as_json)
+      END_KV_SERIALIZE_MAP()
+    };
+
+    struct blocks_entry {
+      block_header_response block_header;
+      std::vector<blocks_transaction_entry> txs;
+
+      blocks_entry() = default;
+
+      blocks_entry(block_header_response block_header, std::vector<blocks_transaction_entry> &txs)
+        : block_header(block_header), txs(txs)
+      {}
+
+      BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE(block_header)
+        KV_SERIALIZE(txs)
+      END_KV_SERIALIZE_MAP()
+    };
+
+struct request_t: public rpc_access_request_base
+    {
+      uint64_t start_height;
+      uint64_t end_height;
+
+      BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE_PARENT(rpc_access_request_base)
+        KV_SERIALIZE(start_height)
+        KV_SERIALIZE(end_height)
+      END_KV_SERIALIZE_MAP()
+    };
+    typedef epee::misc_utils::struct_init<request_t> request;
+
+    struct response_t: public rpc_access_response_base
+    {
+      std::vector<blocks_entry> blocks;
+
+      BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE_PARENT(rpc_response_base)
+        KV_SERIALIZE(blocks)
+      END_KV_SERIALIZE_MAP()
+    };
+    typedef epee::misc_utils::struct_init<response_t> response;
+  };
+
   struct COMMAND_RPC_GET_BLOCK_HEADERS_RANGE
   {
     struct request_t: public rpc_access_request_base
@@ -1701,7 +1761,7 @@ namespace cryptonote
     struct request_t: public rpc_request_base
     {
       bool set;
-      uint32_t in_peers;      
+      uint32_t in_peers;
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE_PARENT(rpc_request_base)
         KV_SERIALIZE_OPT(set, true)
@@ -2438,7 +2498,7 @@ namespace cryptonote
     {
       std::string client;
       int64_t delta_balance;
-      
+
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE_PARENT(rpc_request_base)
         KV_SERIALIZE(client)
@@ -2446,11 +2506,11 @@ namespace cryptonote
       END_KV_SERIALIZE_MAP()
     };
     typedef epee::misc_utils::struct_init<request_t> request;
-    
+
     struct response_t: public rpc_response_base
     {
       uint64_t credits;
-      
+
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE_PARENT(rpc_response_base)
         KV_SERIALIZE(credits)


### PR DESCRIPTION
Retrieve block_header + miner_tx + transactions for a defined range.
miner_tx is always txs[0] and is not counted in num_txes of block_header.
all txs are decoded as json only.