### PR TITLE
qrcodegen: fix compilation with old gcc, use modern cmake

### DIFF
--- a/external/qrcodegen/CMakeLists.txt
+++ b/external/qrcodegen/CMakeLists.txt
@@ -1,7 +1,8 @@
 project(libqrcodegen)
 
 add_library(qrcodegen STATIC QrCode.cpp)
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
+set_target_properties(qrcodegen PROPERTIES POSITION_INDEPENDENT_CODE ON)
+set_target_properties(qrcodegen PROPERTIES CXX_STANDARD 11)
 
 target_include_directories(qrcodegen PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR})


### PR DESCRIPTION
Co-Authored-By: selsta <selsta@users.noreply.github.com>